### PR TITLE
Add reactor and externals to build state

### DIFF
--- a/TFD-front/src/app/build/descendant/descendant.component.html
+++ b/TFD-front/src/app/build/descendant/descendant.component.html
@@ -22,12 +22,8 @@
       </div>
     </div>
     <div class="row">
-      <img class="component" src="https://open.api.nexon.com/static/tfd/img/05e6cc44b4811304825c0e57f0b02297"/>
-
-      <img class="component" src="https://open.api.nexon.com/static/tfd/img/03b9597db4f268682b465b22f37ee609"/>
-      <img class="component" src="https://open.api.nexon.com/static/tfd/img/dec22d4d1b01654a40ef6e59b2080821"/>
-      <img class="component" src="https://open.api.nexon.com/static/tfd/img/8245bef5725f85bfcf325b0c86a9e206"/>
-      <img class="component" src="https://open.api.nexon.com/static/tfd/img/d6b633251eacf77cbdc42639221d0619"/>
+      <reactor-build></reactor-build>
+      <external-build *ngFor="let e of externals(); let i = index" [index]="i"></external-build>
     </div>
   </div>
 </div>

--- a/TFD-front/src/app/build/descendant/descendant.component.ts
+++ b/TFD-front/src/app/build/descendant/descendant.component.ts
@@ -1,6 +1,8 @@
 import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ModuleBuildComponent } from '../module/module.component';
+import { ReactorBuildComponent } from '../reactor/reactor.component';
+import { ExternalBuildComponent } from '../external/external.component';
 import { dataStore } from '../../store/data.store';
 import { selectorData } from '../../types/selector.types';
 import { DescendantDisplayComponent } from './display/descendant-display.component';
@@ -13,7 +15,13 @@ import { buildStore } from '../../store/build.store';
 @Component({
   standalone: true,
   selector: 'descendant-build',
-  imports: [CommonModule, ModuleBuildComponent, DescendantDisplayComponent],
+  imports: [
+    CommonModule,
+    ModuleBuildComponent,
+    DescendantDisplayComponent,
+    ReactorBuildComponent,
+    ExternalBuildComponent,
+  ],
   templateUrl: './descendant.component.html',
   styleUrls: ['./descendant.component.scss', '../main/main.component.scss' ,'../../../styles.scss']
 })
@@ -35,6 +43,8 @@ export class DescedantBuildComponent {
 
   descendant = this.build_store.descendant;
   modules = this.build_store.descendantModules;
+  reactor = this.build_store.reactor;
+  externals = this.build_store.externals;
 
   handleModuleSelected(index: number, module: ModuleResponse) {
     const currentModules = this.modules();

--- a/TFD-front/src/app/build/descendant/descendant.component.ts
+++ b/TFD-front/src/app/build/descendant/descendant.component.ts
@@ -1,13 +1,14 @@
-import { ChangeDetectorRef, Component, inject, signal } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ModuleBuildComponent } from '../module/module.component';
 import { dataStore } from '../../store/data.store';
 import { selectorData } from '../../types/selector.types';
 import { DescendantDisplayComponent } from './display/descendant-display.component';
-import { defaultModule, ModuleResponse } from '../../types/module.types';
+import { ModuleResponse } from '../../types/module.types';
 import { defaultDescendants, DescendantsResponse } from '../../types/descendant.types';
 import { selectorComponent } from '../selector/selector.component';
 import { MatDialog } from '@angular/material/dialog';
+import { buildStore } from '../../store/build.store';
 
 @Component({
   standalone: true,
@@ -18,6 +19,7 @@ import { MatDialog } from '@angular/material/dialog';
 })
 export class DescedantBuildComponent {
   readonly data_store = inject(dataStore);
+  readonly build_store = inject(buildStore);
 
   module_data: selectorData = {
     selectitems: "modules",
@@ -31,11 +33,8 @@ export class DescedantBuildComponent {
     descendant: undefined
   }
 
-  descendant = signal<DescendantsResponse>(defaultDescendants);
-
-  modules = signal<(ModuleResponse)[]>(
-    Array.from({ length: 12 }, () => ({ ...defaultModule }))
-  );
+  descendant = this.build_store.descendant;
+  modules = this.build_store.descendantModules;
 
   handleModuleSelected(index: number, module: ModuleResponse) {
     const currentModules = this.modules();
@@ -50,21 +49,13 @@ export class DescedantBuildComponent {
     }
 
     if (isDuplicate || isDuplicateType || forcedIndex !== index) {
-      this.modules.update(current => {
-        const copy = [...current];
-        copy[index] = { ...copy[index] };
-        return copy;
-      });
+      this.build_store.updateDescendantModule(index, { ...currentModules[index] });
       if (forcedIndex === index) {
         return;
       }
     }
 
-    this.modules.update(current => {
-      const copy = [...current];
-      copy[forcedIndex] = module;
-      return copy;
-    });
+    this.build_store.updateDescendantModule(forcedIndex, module);
   }
 
   constructor(private dialog: MatDialog) {}
@@ -80,7 +71,7 @@ export class DescedantBuildComponent {
       if (res === undefined) {
         res = defaultDescendants;
       }
-      this.descendant.set(res);
+      this.build_store.setDescendant(res);
       this.module_data.descendant = res.descendant_id
 
       //todo: double check compatibles modules

--- a/TFD-front/src/app/build/external/display/external-display.component.html
+++ b/TFD-front/src/app/build/external/display/external-display.component.html
@@ -1,0 +1,8 @@
+<div class="background">
+  @if (external.external_component_id !== 0) {
+    <span class="halo" [ngClass]="external.external_component_tier_id ?? ''"></span>
+    <img class="external" [src]="imageUrl" />
+  } @else {
+    <img class="external" src="../../../../assets/images/logo_tfd_ai.ico" />
+  }
+</div>

--- a/TFD-front/src/app/build/external/display/external-display.component.scss
+++ b/TFD-front/src/app/build/external/display/external-display.component.scss
@@ -1,0 +1,43 @@
+:host {
+  --scale: 1.5;
+}
+
+.background {
+  position: relative;
+  width: calc(60px * var(--scale));
+  height: calc(60px * var(--scale));
+}
+
+.external {
+  position: absolute;
+  top: calc(12px * var(--scale));
+  left: calc(12px * var(--scale));
+  width: calc(36px * var(--scale));
+  height: calc(36px * var(--scale));
+  object-fit: contain;
+}
+
+.halo {
+  position: absolute;
+  top: calc(7px * var(--scale));
+  left: calc(7px * var(--scale));
+  width: calc(46px * var(--scale));
+  height: calc(46px * var(--scale));
+  border-radius: 50%;
+}
+
+.halo.Tier1 {
+  background: radial-gradient(circle, rgba(23, 113, 153, 0.5) 0%, rgba(255, 255, 255, 0) 60%);
+}
+
+.halo.Tier2 {
+  background: radial-gradient(circle, rgba(125, 23, 153, 0.5) 0%, rgba(255, 255, 255, 0) 60%);
+}
+
+.halo.Tier3 {
+  background: radial-gradient(circle, rgba(153, 136, 23, 0.5) 0%, rgba(255, 255, 255, 0) 60%);
+}
+
+.halo.Tier4 {
+  background: radial-gradient(circle, rgba(153, 53, 23, 0.5) 0%, rgba(255, 255, 255, 0) 60%);
+}

--- a/TFD-front/src/app/build/external/display/external-display.component.ts
+++ b/TFD-front/src/app/build/external/display/external-display.component.ts
@@ -1,0 +1,18 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ExternalComponent } from '../../../types/external.types';
+
+@Component({
+  standalone: true,
+  selector: 'external',
+  imports: [CommonModule],
+  templateUrl: './external-display.component.html',
+  styleUrls: ['./external-display.component.scss']
+})
+export class ExternalDisplayComponent {
+  @Input() external!: ExternalComponent;
+
+  get imageUrl(): string {
+    return this.external?.image_url ?? '';
+  }
+}

--- a/TFD-front/src/app/build/external/external.component.html
+++ b/TFD-front/src/app/build/external/external.component.html
@@ -1,0 +1,1 @@
+<external [external]="external()" (click)="openDialog()"></external>

--- a/TFD-front/src/app/build/external/external.component.scss
+++ b/TFD-front/src/app/build/external/external.component.scss
@@ -1,0 +1,3 @@
+:host {
+  display: inline-block;
+}

--- a/TFD-front/src/app/build/external/external.component.ts
+++ b/TFD-front/src/app/build/external/external.component.ts
@@ -1,0 +1,44 @@
+import { Component, inject, Input, computed } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatDialog } from '@angular/material/dialog';
+import { selectorComponent } from '../selector/selector.component';
+import { buildStore } from '../../store/build.store';
+import { selectorData } from '../../types/selector.types';
+import { ExternalComponent as Ext, defaultExternalComponent } from '../../types/external.types';
+import { ExternalDisplayComponent } from './display/external-display.component';
+
+@Component({
+  standalone: true,
+  selector: 'external-build',
+  imports: [CommonModule, ExternalDisplayComponent],
+  templateUrl: './external.component.html',
+  styleUrls: ['./external.component.scss', '../main/main.component.scss', '../../styles.scss']
+})
+export class ExternalBuildComponent {
+  readonly build_store = inject(buildStore);
+  @Input() index = 0;
+
+  external = computed(() => this.build_store.externals()[this.index]);
+
+  externalData: selectorData = {
+    selectitems: 'externals',
+    filterClass: 0,
+    descendant: undefined
+  };
+
+  constructor(private dialog: MatDialog) {}
+
+  openDialog(): void {
+    const dialogRef = this.dialog.open(selectorComponent, {
+      autoFocus: true,
+      data: this.externalData
+    });
+
+    dialogRef.afterClosed().subscribe((res: Ext) => {
+      if (res === undefined) {
+        res = defaultExternalComponent;
+      }
+      this.build_store.setExternal(this.index, res);
+    });
+  }
+}

--- a/TFD-front/src/app/build/main/main.component.html
+++ b/TFD-front/src/app/build/main/main.component.html
@@ -20,8 +20,8 @@
   </div>
 
   <div class="column weapons-row"> <!-- list weapons -->
-    <ng-container  *ngFor="let _ of weaponRange()"> <!-- change to @for -->
-      <weapon-build></weapon-build>
+    <ng-container *ngFor="let _ of weaponRange(); let i = index">
+      <weapon-build [index]="i"></weapon-build>
     </ng-container>
   </div>
 </div>

--- a/TFD-front/src/app/build/reactor/display/reactor-display.component.html
+++ b/TFD-front/src/app/build/reactor/display/reactor-display.component.html
@@ -1,0 +1,8 @@
+<div class="background">
+  @if (reactor.reactor_id !== 0) {
+    <span class="halo" [ngClass]="reactor.reactor_tier_id ?? ''"></span>
+    <img class="reactor" [src]="imageUrl" />
+  } @else {
+    <img class="reactor" src="../../../../assets/images/logo_tfd_ai.ico" />
+  }
+</div>

--- a/TFD-front/src/app/build/reactor/display/reactor-display.component.scss
+++ b/TFD-front/src/app/build/reactor/display/reactor-display.component.scss
@@ -1,0 +1,43 @@
+:host {
+  --scale: 1.5;
+}
+
+.background {
+  position: relative;
+  width: calc(60px * var(--scale));
+  height: calc(60px * var(--scale));
+}
+
+.reactor {
+  position: absolute;
+  top: calc(12px * var(--scale));
+  left: calc(12px * var(--scale));
+  width: calc(36px * var(--scale));
+  height: calc(36px * var(--scale));
+  object-fit: contain;
+}
+
+.halo {
+  position: absolute;
+  top: calc(7px * var(--scale));
+  left: calc(7px * var(--scale));
+  width: calc(46px * var(--scale));
+  height: calc(46px * var(--scale));
+  border-radius: 50%;
+}
+
+.halo.Tier1 {
+  background: radial-gradient(circle, rgba(23, 113, 153, 0.5) 0%, rgba(255, 255, 255, 0) 60%);
+}
+
+.halo.Tier2 {
+  background: radial-gradient(circle, rgba(125, 23, 153, 0.5) 0%, rgba(255, 255, 255, 0) 60%);
+}
+
+.halo.Tier3 {
+  background: radial-gradient(circle, rgba(153, 136, 23, 0.5) 0%, rgba(255, 255, 255, 0) 60%);
+}
+
+.halo.Tier4 {
+  background: radial-gradient(circle, rgba(153, 53, 23, 0.5) 0%, rgba(255, 255, 255, 0) 60%);
+}

--- a/TFD-front/src/app/build/reactor/display/reactor-display.component.ts
+++ b/TFD-front/src/app/build/reactor/display/reactor-display.component.ts
@@ -1,0 +1,18 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Reactor } from '../../../types/reactor.types';
+
+@Component({
+  standalone: true,
+  selector: 'reactor',
+  imports: [CommonModule],
+  templateUrl: './reactor-display.component.html',
+  styleUrls: ['./reactor-display.component.scss']
+})
+export class ReactorDisplayComponent {
+  @Input() reactor!: Reactor;
+
+  get imageUrl(): string {
+    return this.reactor?.image_url ?? '';
+  }
+}

--- a/TFD-front/src/app/build/reactor/reactor.component.html
+++ b/TFD-front/src/app/build/reactor/reactor.component.html
@@ -1,0 +1,1 @@
+<reactor [reactor]="reactor()" (click)="openDialog()"></reactor>

--- a/TFD-front/src/app/build/reactor/reactor.component.scss
+++ b/TFD-front/src/app/build/reactor/reactor.component.scss
@@ -1,0 +1,3 @@
+:host {
+  display: inline-block;
+}

--- a/TFD-front/src/app/build/reactor/reactor.component.ts
+++ b/TFD-front/src/app/build/reactor/reactor.component.ts
@@ -1,0 +1,42 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatDialog } from '@angular/material/dialog';
+import { selectorComponent } from '../selector/selector.component';
+import { buildStore } from '../../store/build.store';
+import { selectorData } from '../../types/selector.types';
+import { Reactor, defaultReactor } from '../../types/reactor.types';
+import { ReactorDisplayComponent } from './display/reactor-display.component';
+
+@Component({
+  standalone: true,
+  selector: 'reactor-build',
+  imports: [CommonModule, ReactorDisplayComponent],
+  templateUrl: './reactor.component.html',
+  styleUrls: ['./reactor.component.scss', '../main/main.component.scss', '../../styles.scss']
+})
+export class ReactorBuildComponent {
+  readonly build_store = inject(buildStore);
+  reactor = this.build_store.reactor;
+
+  reactorData: selectorData = {
+    selectitems: 'reactors',
+    filterClass: 0,
+    descendant: undefined
+  };
+
+  constructor(private dialog: MatDialog) {}
+
+  openDialog(): void {
+    const dialogRef = this.dialog.open(selectorComponent, {
+      autoFocus: true,
+      data: this.reactorData
+    });
+
+    dialogRef.afterClosed().subscribe((res: Reactor) => {
+      if (res === undefined) {
+        res = defaultReactor;
+      }
+      this.build_store.setReactor(res);
+    });
+  }
+}

--- a/TFD-front/src/app/build/selector/selector.component.html
+++ b/TFD-front/src/app/build/selector/selector.component.html
@@ -18,6 +18,14 @@
       @for (m of filteredWeapons(); track m.id) {
         <weapon [weapon]="m" (click)="selectWeapon(m)"></weapon>
       }
+    } @else if (type === "reactors") {
+      @for (m of filteredReactors(); track m.id) {
+        <reactor [reactor]="m" (click)="selectReactor(m)"></reactor>
+      }
+    } @else if (type === "externals") {
+      @for (m of filteredExternals(); track m.id) {
+        <external [external]="m" (click)="selectExternal(m)"></external>
+      }
     }
   </div>
 </div>

--- a/TFD-front/src/app/build/selector/selector.component.ts
+++ b/TFD-front/src/app/build/selector/selector.component.ts
@@ -2,6 +2,8 @@ import {Component, Inject, inject, Input} from '@angular/core';
 import { CommonModule } from '@angular/common';
 import {dataStore, defaultTranslate, TranslationString} from '../../store/data.store';
 import { ModuleComponent } from '../module/display/module-display.component';
+import { ReactorDisplayComponent } from '../reactor/display/reactor-display.component';
+import { ExternalDisplayComponent } from '../external/display/external-display.component';
 import {MAT_DIALOG_DATA, MatDialogModule, MatDialogRef} from '@angular/material/dialog';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { FormsModule } from '@angular/forms';
@@ -11,11 +13,23 @@ import { DescendantDisplayComponent } from '../descendant/display/descendant-dis
 import { DescendantsResponse } from '../../types/descendant.types';
 import { WeaponDisplayComponent } from '../weapon/display/weapon-display.component';
 import { WeaponResponse } from '../../types/weapon.types';
+import { Reactor } from '../../types/reactor.types';
+import { ExternalComponent } from '../../types/external.types';
 
 @Component({
   standalone: true,
   selector: 'selector',
-  imports: [CommonModule, ModuleComponent, MatDialogModule, MatProgressSpinnerModule, FormsModule, DescendantDisplayComponent, WeaponDisplayComponent],
+  imports: [
+    CommonModule,
+    ModuleComponent,
+    MatDialogModule,
+    MatProgressSpinnerModule,
+    FormsModule,
+    DescendantDisplayComponent,
+    WeaponDisplayComponent,
+    ReactorDisplayComponent,
+    ExternalDisplayComponent,
+  ],
   templateUrl: './selector.component.html',
   styleUrls: ['./selector.component.scss', '../../../styles.scss']
 })
@@ -63,6 +77,14 @@ export class selectorComponent {
     return this.data_store.weaponResource.value()
   }
 
+  filteredReactors() {
+    return this.data_store.reactorResource.value()
+  }
+
+  filteredExternals() {
+    return this.data_store.externalResource.value()
+  }
+
   get_translate(id: number): TranslationString {
     if (this.data_store.translationResource.hasValue()) {
       return this.data_store.translationResource.value()[id-1]
@@ -89,6 +111,12 @@ export class selectorComponent {
     if (!this.data_store.weaponResource.hasValue()) {
       this.data_store.load_weapons()
     }
+    if (!this.data_store.reactorResource.hasValue()) {
+      this.data_store.load_reactors()
+    }
+    if (!this.data_store.externalResource.hasValue()) {
+      this.data_store.load_externals()
+    }
   }
 
   selectModules(module: ModuleResponse): void {
@@ -101,5 +129,13 @@ export class selectorComponent {
 
   selectWeapon(weapon: WeaponResponse ): void {
     this.dialogRef.close(weapon);
+  }
+
+  selectReactor(reactor: Reactor): void {
+    this.dialogRef.close(reactor);
+  }
+
+  selectExternal(external: ExternalComponent): void {
+    this.dialogRef.close(external);
   }
 }

--- a/TFD-front/src/app/build/weapon/weapon.component.html
+++ b/TFD-front/src/app/build/weapon/weapon.component.html
@@ -1,10 +1,18 @@
 <div class="weapon" @fadeSlide>
   <weapon [weapon]="weapon()" (click)="openDialog()"></weapon>
   <div class="row">
-    <module-build *ngFor="let m of [1,2,3,4,5]" [data]="this.module_data"/>
+    <module-build *ngFor="let m of modules().slice(0,5); let i = index"
+                 [module]="m"
+                 [data]="this.module_data"
+                 (moduleSelected)="handleModuleSelected(i, $event)">
+    </module-build>
   </div>
   <div class="row">
-    <module-build *ngFor="let m of [1,2,3,4,5]" [data]="this.module_data"/>
+    <module-build *ngFor="let m of modules().slice(5,10); let i = index"
+                 [module]="m"
+                 [data]="this.module_data"
+                 (moduleSelected)="handleModuleSelected(i + 5, $event)">
+    </module-build>
   </div>
   <!-- ajouter les Cores-->
 </div>

--- a/TFD-front/src/app/build/weapon/weapon.component.ts
+++ b/TFD-front/src/app/build/weapon/weapon.component.ts
@@ -1,4 +1,4 @@
-import { Component, signal } from '@angular/core';
+import { Component, inject, computed, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import {ModuleBuildComponent} from '../module/module.component';
 import { selectorData } from '../../types/selector.types';
@@ -6,6 +6,8 @@ import { WeaponDisplayComponent } from './display/weapon-display.component';
 import { selectorComponent } from '../selector/selector.component';
 import { MatDialog } from '@angular/material/dialog';
 import { defaultWeapon, WeaponResponse } from '../../types/weapon.types';
+import { ModuleResponse } from '../../types/module.types';
+import { buildStore } from '../../store/build.store';
 
 @Component({
   standalone: true,
@@ -15,8 +17,11 @@ import { defaultWeapon, WeaponResponse } from '../../types/weapon.types';
   styleUrls: ['./weapon.component.scss', '../main/main.component.scss' ,'../../../styles.scss']
 })
 export class WeaponBuildComponent {
+  @Input() index = 0;
+  readonly build_store = inject(buildStore);
 
-  weapon = signal<WeaponResponse>(defaultWeapon);
+  weapon = computed(() => this.build_store.weapons()[this.index]);
+  modules = computed(() => this.build_store.weaponsModules()[this.index]);
 
   weapon_data: selectorData = {
     selectitems: "weapons",
@@ -32,6 +37,10 @@ export class WeaponBuildComponent {
 
   constructor(private dialog: MatDialog,) {}
 
+  handleModuleSelected(index: number, module: ModuleResponse) {
+    this.build_store.updateWeaponModule(this.index, index, module);
+  }
+
   openDialog(): void {
 
     const dialogRef = this.dialog.open(selectorComponent, {
@@ -42,7 +51,7 @@ export class WeaponBuildComponent {
       if (res === undefined) {
         res = defaultWeapon;
       }
-      this.weapon.set(res);
+      this.build_store.setWeaponAt(this.index, res);
       //TODO: make a fonction cause some weapons are not working and somtime there is incompatibles mods showing up
       this.module_data.filterClass = res.weapon_rounds_type_id
     });

--- a/TFD-front/src/app/store/build.store.ts
+++ b/TFD-front/src/app/store/build.store.ts
@@ -1,0 +1,61 @@
+import { signalStore, withState, withMethods, patchState } from '@ngrx/signals';
+import { ModuleResponse, defaultModule } from '../types/module.types';
+import { DescendantsResponse, defaultDescendants } from '../types/descendant.types';
+import { WeaponResponse, defaultWeapon } from '../types/weapon.types';
+import { Reactor, defaultReactor } from '../types/reactor.types';
+import { ExternalComponent, defaultExternalComponent } from '../types/external.types';
+
+export interface BuildState {
+  descendant: DescendantsResponse;
+  descendantModules: ModuleResponse[];
+  weapons: WeaponResponse[];
+  weaponsModules: ModuleResponse[][];
+  reactor: Reactor;
+  externals: ExternalComponent[];
+}
+
+const initialBuildState: BuildState = {
+  descendant: defaultDescendants,
+  descendantModules: Array.from({ length: 12 }, () => ({ ...defaultModule })),
+  weapons: Array.from({ length: 3 }, () => ({ ...defaultWeapon })),
+  weaponsModules: Array.from({ length: 3 }, () =>
+    Array.from({ length: 10 }, () => ({ ...defaultModule }))
+  ),
+  reactor: defaultReactor,
+  externals: Array.from({ length: 4 }, () => ({ ...defaultExternalComponent })),
+};
+
+export const buildStore = signalStore(
+  {
+    providedIn: 'root'
+  },
+  withState<BuildState>(initialBuildState),
+  withMethods((store) => ({
+    setDescendant: (desc: DescendantsResponse) => {
+      patchState(store, { descendant: desc });
+    },
+    updateDescendantModule: (index: number, module: ModuleResponse) => {
+      const modules = [...store.descendantModules()];
+      modules[index] = module;
+      patchState(store, { descendantModules: modules });
+    },
+    setWeaponAt: (index: number, weapon: WeaponResponse) => {
+      const weapons = [...store.weapons()];
+      weapons[index] = weapon;
+      patchState(store, { weapons });
+    },
+    updateWeaponModule: (weaponIndex: number, moduleIndex: number, module: ModuleResponse) => {
+      const moduleArrays = store.weaponsModules().map(arr => [...arr]);
+      moduleArrays[weaponIndex][moduleIndex] = module;
+      patchState(store, { weaponsModules: moduleArrays });
+    },
+    setReactor: (reactor: Reactor) => {
+      patchState(store, { reactor });
+    },
+    setExternal: (index: number, external: ExternalComponent) => {
+      const externals = [...store.externals()];
+      externals[index] = external;
+      patchState(store, { externals });
+    },
+  }))
+);

--- a/TFD-front/src/app/store/data.store.ts
+++ b/TFD-front/src/app/store/data.store.ts
@@ -242,8 +242,18 @@ export const dataStore = signalStore(
         store.translationResource?.reload()
       }
     },
+    load_externals: () => {
+      patchState(store, { unlock: { ...store.unlock(), externals: true } });
+      store.externalResource?.reload();
+    },
+    load_reactors: () => {
+      patchState(store, { unlock: { ...store.unlock(), reactors: true } });
+      store.reactorResource?.reload();
+    },
     refresh_modules: () => store.modulesResource?.reload(),
     refresh_translation: () => store.translationResource?.reload(),
     refresh_descendants: () => store.descendantResource?.reload(),
+    refresh_externals: () => store.externalResource?.reload(),
+    refresh_reactors: () => store.reactorResource?.reload(),
   }))
 );

--- a/TFD-front/src/app/types/external.types.ts
+++ b/TFD-front/src/app/types/external.types.ts
@@ -1,0 +1,33 @@
+export interface ExtBaseStat {
+  level: number;
+  stat_id: number;
+  stat_value: number;
+}
+
+export interface ExtSetDetail {
+  set_option_id: number;
+  set_count: number;
+  set_option_effect_id: number;
+}
+
+export interface ExternalComponent {
+  id: number;
+  external_component_id: number;
+  external_component_name_id: number;
+  equipment_type_id: number;
+  image_url?: string;
+  external_component_tier_id?: string;
+  base_stat: ExtBaseStat[];
+  set_option_detail: ExtSetDetail[];
+}
+
+export const defaultExternalComponent: ExternalComponent = {
+  id: 0,
+  external_component_id: 0,
+  external_component_name_id: 0,
+  equipment_type_id: 0,
+  image_url: '',
+  external_component_tier_id: '',
+  base_stat: [],
+  set_option_detail: [],
+};

--- a/TFD-front/src/app/types/reactor.types.ts
+++ b/TFD-front/src/app/types/reactor.types.ts
@@ -1,0 +1,33 @@
+export interface ReactorBaseStat {
+  level: number;
+  stat_id: number;
+  stat_value: number;
+}
+
+export interface ReactorSetDetail {
+  set_option_id: number;
+  set_count: number;
+  set_option_effect_id: number;
+}
+
+export interface Reactor {
+  id: number;
+  reactor_id: number;
+  reactor_name_id: number;
+  equipment_type_id: number;
+  image_url?: string;
+  reactor_tier_id?: string;
+  base_stat: ReactorBaseStat[];
+  set_option_detail: ReactorSetDetail[];
+}
+
+export const defaultReactor: Reactor = {
+  id: 0,
+  reactor_id: 0,
+  reactor_name_id: 0,
+  equipment_type_id: 0,
+  image_url: '',
+  reactor_tier_id: '',
+  base_stat: [],
+  set_option_detail: [],
+};


### PR DESCRIPTION
## Summary
- support multiple weapons in build store
- track reactor and external components in build store
- implement new types for reactor and external components
- update weapon component to handle weapon index
- wire up weapon indices in main build template

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6840127677008320b0bdfae9746008c8