### PR TITLE
Add reactor and external component selector

### DIFF
--- a/TFD-front/src/app/build/descendant/descendant.component.html
+++ b/TFD-front/src/app/build/descendant/descendant.component.html
@@ -22,12 +22,8 @@
       </div>
     </div>
     <div class="row">
-      <img class="component" src="https://open.api.nexon.com/static/tfd/img/05e6cc44b4811304825c0e57f0b02297"/>
-
-      <img class="component" src="https://open.api.nexon.com/static/tfd/img/03b9597db4f268682b465b22f37ee609"/>
-      <img class="component" src="https://open.api.nexon.com/static/tfd/img/dec22d4d1b01654a40ef6e59b2080821"/>
-      <img class="component" src="https://open.api.nexon.com/static/tfd/img/8245bef5725f85bfcf325b0c86a9e206"/>
-      <img class="component" src="https://open.api.nexon.com/static/tfd/img/d6b633251eacf77cbdc42639221d0619"/>
+      <reactor-build></reactor-build>
+      <external-build *ngFor="let e of externals(); let i = index" [index]="i"></external-build>
     </div>
   </div>
 </div>

--- a/TFD-front/src/app/build/descendant/descendant.component.ts
+++ b/TFD-front/src/app/build/descendant/descendant.component.ts
@@ -1,6 +1,8 @@
 import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ModuleBuildComponent } from '../module/module.component';
+import { ReactorBuildComponent } from '../reactor/reactor.component';
+import { ExternalBuildComponent } from '../external/external.component';
 import { dataStore } from '../../store/data.store';
 import { selectorData } from '../../types/selector.types';
 import { DescendantDisplayComponent } from './display/descendant-display.component';
@@ -13,7 +15,13 @@ import { buildStore } from '../../store/build.store';
 @Component({
   standalone: true,
   selector: 'descendant-build',
-  imports: [CommonModule, ModuleBuildComponent, DescendantDisplayComponent],
+  imports: [
+    CommonModule,
+    ModuleBuildComponent,
+    DescendantDisplayComponent,
+    ReactorBuildComponent,
+    ExternalBuildComponent,
+  ],
   templateUrl: './descendant.component.html',
   styleUrls: ['./descendant.component.scss', '../main/main.component.scss' ,'../../../styles.scss']
 })
@@ -35,6 +43,8 @@ export class DescedantBuildComponent {
 
   descendant = this.build_store.descendant;
   modules = this.build_store.descendantModules;
+  reactor = this.build_store.reactor;
+  externals = this.build_store.externals;
 
   handleModuleSelected(index: number, module: ModuleResponse) {
     const currentModules = this.modules();

--- a/TFD-front/src/app/build/external/display/external-display.component.html
+++ b/TFD-front/src/app/build/external/display/external-display.component.html
@@ -1,5 +1,4 @@
 <div class="background">
-  <img class="external-back" src="../../../../assets/images/module.png" />
   @if (external.external_component_id !== 0) {
     <span class="halo" [ngClass]="external.external_component_tier_id ?? ''"></span>
     <img class="external" [src]="imageUrl" />

--- a/TFD-front/src/app/build/external/display/external-display.component.html
+++ b/TFD-front/src/app/build/external/display/external-display.component.html
@@ -1,0 +1,9 @@
+<div class="background">
+  <img class="external-back" src="../../../../assets/images/module.png" />
+  @if (external.external_component_id !== 0) {
+    <span class="halo" [ngClass]="external.external_component_tier_id ?? ''"></span>
+    <img class="external" [src]="imageUrl" />
+  } @else {
+    <img class="external" src="../../../../assets/images/logo_tfd_ai.ico" />
+  }
+</div>

--- a/TFD-front/src/app/build/external/display/external-display.component.scss
+++ b/TFD-front/src/app/build/external/display/external-display.component.scss
@@ -1,0 +1,45 @@
+:host {
+  --scale: 1.5;
+}
+
+.background {
+  position: relative;
+  width: calc(60px * var(--scale));
+  height: calc(60px * var(--scale));
+}
+
+.external-back {
+  width: calc(60px * var(--scale));
+}
+
+.external {
+  position: absolute;
+  top: calc(12px * var(--scale));
+  left: calc(12px * var(--scale));
+  width: calc(36px * var(--scale));
+}
+
+.halo {
+  position: absolute;
+  top: calc(7px * var(--scale));
+  left: calc(7px * var(--scale));
+  width: calc(46px * var(--scale));
+  height: calc(46px * var(--scale));
+  border-radius: 50%;
+}
+
+.halo.Tier1 {
+  background: radial-gradient(circle, rgba(23, 113, 153, 0.5) 0%, rgba(255, 255, 255, 0) 60%);
+}
+
+.halo.Tier2 {
+  background: radial-gradient(circle, rgba(125, 23, 153, 0.5) 0%, rgba(255, 255, 255, 0) 60%);
+}
+
+.halo.Tier3 {
+  background: radial-gradient(circle, rgba(153, 136, 23, 0.5) 0%, rgba(255, 255, 255, 0) 60%);
+}
+
+.halo.Tier4 {
+  background: radial-gradient(circle, rgba(153, 53, 23, 0.5) 0%, rgba(255, 255, 255, 0) 60%);
+}

--- a/TFD-front/src/app/build/external/display/external-display.component.scss
+++ b/TFD-front/src/app/build/external/display/external-display.component.scss
@@ -8,15 +8,13 @@
   height: calc(60px * var(--scale));
 }
 
-.external-back {
-  width: calc(60px * var(--scale));
-}
-
 .external {
   position: absolute;
   top: calc(12px * var(--scale));
   left: calc(12px * var(--scale));
   width: calc(36px * var(--scale));
+  height: calc(36px * var(--scale));
+  object-fit: contain;
 }
 
 .halo {

--- a/TFD-front/src/app/build/external/display/external-display.component.ts
+++ b/TFD-front/src/app/build/external/display/external-display.component.ts
@@ -1,0 +1,18 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ExternalComponent } from '../../../types/external.types';
+
+@Component({
+  standalone: true,
+  selector: 'external',
+  imports: [CommonModule],
+  templateUrl: './external-display.component.html',
+  styleUrls: ['./external-display.component.scss']
+})
+export class ExternalDisplayComponent {
+  @Input() external!: ExternalComponent;
+
+  get imageUrl(): string {
+    return this.external?.image_url ?? '';
+  }
+}

--- a/TFD-front/src/app/build/external/external.component.html
+++ b/TFD-front/src/app/build/external/external.component.html
@@ -1,0 +1,1 @@
+<external [external]="external()" (click)="openDialog()"></external>

--- a/TFD-front/src/app/build/external/external.component.scss
+++ b/TFD-front/src/app/build/external/external.component.scss
@@ -1,0 +1,3 @@
+:host {
+  display: inline-block;
+}

--- a/TFD-front/src/app/build/external/external.component.ts
+++ b/TFD-front/src/app/build/external/external.component.ts
@@ -1,0 +1,44 @@
+import { Component, inject, Input, computed } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatDialog } from '@angular/material/dialog';
+import { selectorComponent } from '../selector/selector.component';
+import { buildStore } from '../../store/build.store';
+import { selectorData } from '../../types/selector.types';
+import { ExternalComponent as Ext, defaultExternalComponent } from '../../types/external.types';
+import { ExternalDisplayComponent } from './display/external-display.component';
+
+@Component({
+  standalone: true,
+  selector: 'external-build',
+  imports: [CommonModule, ExternalDisplayComponent],
+  templateUrl: './external.component.html',
+  styleUrls: ['./external.component.scss', '../main/main.component.scss', '../../styles.scss']
+})
+export class ExternalBuildComponent {
+  readonly build_store = inject(buildStore);
+  @Input() index = 0;
+
+  external = computed(() => this.build_store.externals()[this.index]);
+
+  externalData: selectorData = {
+    selectitems: 'externals',
+    filterClass: 0,
+    descendant: undefined
+  };
+
+  constructor(private dialog: MatDialog) {}
+
+  openDialog(): void {
+    const dialogRef = this.dialog.open(selectorComponent, {
+      autoFocus: true,
+      data: this.externalData
+    });
+
+    dialogRef.afterClosed().subscribe((res: Ext) => {
+      if (res === undefined) {
+        res = defaultExternalComponent;
+      }
+      this.build_store.setExternal(this.index, res);
+    });
+  }
+}

--- a/TFD-front/src/app/build/reactor/display/reactor-display.component.html
+++ b/TFD-front/src/app/build/reactor/display/reactor-display.component.html
@@ -1,5 +1,4 @@
 <div class="background">
-  <img class="reactor-back" src="../../../../assets/images/module.png" />
   @if (reactor.reactor_id !== 0) {
     <span class="halo" [ngClass]="reactor.reactor_tier_id ?? ''"></span>
     <img class="reactor" [src]="imageUrl" />

--- a/TFD-front/src/app/build/reactor/display/reactor-display.component.html
+++ b/TFD-front/src/app/build/reactor/display/reactor-display.component.html
@@ -1,0 +1,9 @@
+<div class="background">
+  <img class="reactor-back" src="../../../../assets/images/module.png" />
+  @if (reactor.reactor_id !== 0) {
+    <span class="halo" [ngClass]="reactor.reactor_tier_id ?? ''"></span>
+    <img class="reactor" [src]="imageUrl" />
+  } @else {
+    <img class="reactor" src="../../../../assets/images/logo_tfd_ai.ico" />
+  }
+</div>

--- a/TFD-front/src/app/build/reactor/display/reactor-display.component.scss
+++ b/TFD-front/src/app/build/reactor/display/reactor-display.component.scss
@@ -1,0 +1,45 @@
+:host {
+  --scale: 1.5;
+}
+
+.background {
+  position: relative;
+  width: calc(60px * var(--scale));
+  height: calc(60px * var(--scale));
+}
+
+.reactor-back {
+  width: calc(60px * var(--scale));
+}
+
+.reactor {
+  position: absolute;
+  top: calc(12px * var(--scale));
+  left: calc(12px * var(--scale));
+  width: calc(36px * var(--scale));
+}
+
+.halo {
+  position: absolute;
+  top: calc(7px * var(--scale));
+  left: calc(7px * var(--scale));
+  width: calc(46px * var(--scale));
+  height: calc(46px * var(--scale));
+  border-radius: 50%;
+}
+
+.halo.Tier1 {
+  background: radial-gradient(circle, rgba(23, 113, 153, 0.5) 0%, rgba(255, 255, 255, 0) 60%);
+}
+
+.halo.Tier2 {
+  background: radial-gradient(circle, rgba(125, 23, 153, 0.5) 0%, rgba(255, 255, 255, 0) 60%);
+}
+
+.halo.Tier3 {
+  background: radial-gradient(circle, rgba(153, 136, 23, 0.5) 0%, rgba(255, 255, 255, 0) 60%);
+}
+
+.halo.Tier4 {
+  background: radial-gradient(circle, rgba(153, 53, 23, 0.5) 0%, rgba(255, 255, 255, 0) 60%);
+}

--- a/TFD-front/src/app/build/reactor/display/reactor-display.component.scss
+++ b/TFD-front/src/app/build/reactor/display/reactor-display.component.scss
@@ -8,15 +8,13 @@
   height: calc(60px * var(--scale));
 }
 
-.reactor-back {
-  width: calc(60px * var(--scale));
-}
-
 .reactor {
   position: absolute;
   top: calc(12px * var(--scale));
   left: calc(12px * var(--scale));
   width: calc(36px * var(--scale));
+  height: calc(36px * var(--scale));
+  object-fit: contain;
 }
 
 .halo {

--- a/TFD-front/src/app/build/reactor/display/reactor-display.component.ts
+++ b/TFD-front/src/app/build/reactor/display/reactor-display.component.ts
@@ -1,0 +1,18 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Reactor } from '../../../types/reactor.types';
+
+@Component({
+  standalone: true,
+  selector: 'reactor',
+  imports: [CommonModule],
+  templateUrl: './reactor-display.component.html',
+  styleUrls: ['./reactor-display.component.scss']
+})
+export class ReactorDisplayComponent {
+  @Input() reactor!: Reactor;
+
+  get imageUrl(): string {
+    return this.reactor?.image_url ?? '';
+  }
+}

--- a/TFD-front/src/app/build/reactor/reactor.component.html
+++ b/TFD-front/src/app/build/reactor/reactor.component.html
@@ -1,0 +1,1 @@
+<reactor [reactor]="reactor()" (click)="openDialog()"></reactor>

--- a/TFD-front/src/app/build/reactor/reactor.component.scss
+++ b/TFD-front/src/app/build/reactor/reactor.component.scss
@@ -1,0 +1,3 @@
+:host {
+  display: inline-block;
+}

--- a/TFD-front/src/app/build/reactor/reactor.component.ts
+++ b/TFD-front/src/app/build/reactor/reactor.component.ts
@@ -1,0 +1,42 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatDialog } from '@angular/material/dialog';
+import { selectorComponent } from '../selector/selector.component';
+import { buildStore } from '../../store/build.store';
+import { selectorData } from '../../types/selector.types';
+import { Reactor, defaultReactor } from '../../types/reactor.types';
+import { ReactorDisplayComponent } from './display/reactor-display.component';
+
+@Component({
+  standalone: true,
+  selector: 'reactor-build',
+  imports: [CommonModule, ReactorDisplayComponent],
+  templateUrl: './reactor.component.html',
+  styleUrls: ['./reactor.component.scss', '../main/main.component.scss', '../../styles.scss']
+})
+export class ReactorBuildComponent {
+  readonly build_store = inject(buildStore);
+  reactor = this.build_store.reactor;
+
+  reactorData: selectorData = {
+    selectitems: 'reactors',
+    filterClass: 0,
+    descendant: undefined
+  };
+
+  constructor(private dialog: MatDialog) {}
+
+  openDialog(): void {
+    const dialogRef = this.dialog.open(selectorComponent, {
+      autoFocus: true,
+      data: this.reactorData
+    });
+
+    dialogRef.afterClosed().subscribe((res: Reactor) => {
+      if (res === undefined) {
+        res = defaultReactor;
+      }
+      this.build_store.setReactor(res);
+    });
+  }
+}

--- a/TFD-front/src/app/build/selector/selector.component.html
+++ b/TFD-front/src/app/build/selector/selector.component.html
@@ -18,6 +18,14 @@
       @for (m of filteredWeapons(); track m.id) {
         <weapon [weapon]="m" (click)="selectWeapon(m)"></weapon>
       }
+    } @else if (type === "reactors") {
+      @for (m of filteredReactors(); track m.id) {
+        <reactor [reactor]="m" (click)="selectReactor(m)"></reactor>
+      }
+    } @else if (type === "externals") {
+      @for (m of filteredExternals(); track m.id) {
+        <external [external]="m" (click)="selectExternal(m)"></external>
+      }
     }
   </div>
 </div>

--- a/TFD-front/src/app/build/selector/selector.component.ts
+++ b/TFD-front/src/app/build/selector/selector.component.ts
@@ -2,6 +2,8 @@ import {Component, Inject, inject, Input} from '@angular/core';
 import { CommonModule } from '@angular/common';
 import {dataStore, defaultTranslate, TranslationString} from '../../store/data.store';
 import { ModuleComponent } from '../module/display/module-display.component';
+import { ReactorDisplayComponent } from '../reactor/display/reactor-display.component';
+import { ExternalDisplayComponent } from '../external/display/external-display.component';
 import {MAT_DIALOG_DATA, MatDialogModule, MatDialogRef} from '@angular/material/dialog';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { FormsModule } from '@angular/forms';
@@ -11,11 +13,23 @@ import { DescendantDisplayComponent } from '../descendant/display/descendant-dis
 import { DescendantsResponse } from '../../types/descendant.types';
 import { WeaponDisplayComponent } from '../weapon/display/weapon-display.component';
 import { WeaponResponse } from '../../types/weapon.types';
+import { Reactor } from '../../types/reactor.types';
+import { ExternalComponent } from '../../types/external.types';
 
 @Component({
   standalone: true,
   selector: 'selector',
-  imports: [CommonModule, ModuleComponent, MatDialogModule, MatProgressSpinnerModule, FormsModule, DescendantDisplayComponent, WeaponDisplayComponent],
+  imports: [
+    CommonModule,
+    ModuleComponent,
+    MatDialogModule,
+    MatProgressSpinnerModule,
+    FormsModule,
+    DescendantDisplayComponent,
+    WeaponDisplayComponent,
+    ReactorDisplayComponent,
+    ExternalDisplayComponent,
+  ],
   templateUrl: './selector.component.html',
   styleUrls: ['./selector.component.scss', '../../../styles.scss']
 })
@@ -63,6 +77,14 @@ export class selectorComponent {
     return this.data_store.weaponResource.value()
   }
 
+  filteredReactors() {
+    return this.data_store.reactorResource.value()
+  }
+
+  filteredExternals() {
+    return this.data_store.externalResource.value()
+  }
+
   get_translate(id: number): TranslationString {
     if (this.data_store.translationResource.hasValue()) {
       return this.data_store.translationResource.value()[id-1]
@@ -89,6 +111,12 @@ export class selectorComponent {
     if (!this.data_store.weaponResource.hasValue()) {
       this.data_store.load_weapons()
     }
+    if (!this.data_store.reactorResource.hasValue()) {
+      this.data_store.load_reactors()
+    }
+    if (!this.data_store.externalResource.hasValue()) {
+      this.data_store.load_externals()
+    }
   }
 
   selectModules(module: ModuleResponse): void {
@@ -101,5 +129,13 @@ export class selectorComponent {
 
   selectWeapon(weapon: WeaponResponse ): void {
     this.dialogRef.close(weapon);
+  }
+
+  selectReactor(reactor: Reactor): void {
+    this.dialogRef.close(reactor);
+  }
+
+  selectExternal(external: ExternalComponent): void {
+    this.dialogRef.close(external);
   }
 }

--- a/TFD-front/src/app/store/data.store.ts
+++ b/TFD-front/src/app/store/data.store.ts
@@ -242,8 +242,18 @@ export const dataStore = signalStore(
         store.translationResource?.reload()
       }
     },
+    load_externals: () => {
+      patchState(store, { unlock: { ...store.unlock(), externals: true } });
+      store.externalResource?.reload();
+    },
+    load_reactors: () => {
+      patchState(store, { unlock: { ...store.unlock(), reactors: true } });
+      store.reactorResource?.reload();
+    },
     refresh_modules: () => store.modulesResource?.reload(),
     refresh_translation: () => store.translationResource?.reload(),
     refresh_descendants: () => store.descendantResource?.reload(),
+    refresh_externals: () => store.externalResource?.reload(),
+    refresh_reactors: () => store.reactorResource?.reload(),
   }))
 );


### PR DESCRIPTION
## Summary
- support loading reactors and external components in the data store
- allow selecting reactors and external components in selector dialog
- display halo effect for tier on new components
- add ReactorBuild and ExternalBuild components
- integrate reactor and externals into descendant build

## Testing
- `npm test` *(fails: Chrome not found)*

------
https://chatgpt.com/codex/tasks/task_e_684045fbeb008320bd1b2353c3822d47