### PR TITLE
Enable multilingual front-end

### DIFF
--- a/TFD-front/src/app/app.component.html
+++ b/TFD-front/src/app/app.component.html
@@ -2,19 +2,19 @@
   <sidebar></sidebar>
   <div class="tabs sidebar-small">
     <mat-tab-group [(selectedIndex)]="selectedIndex">
-      <mat-tab label="Search">
+      <mat-tab [label]="label('search')">
         <div class="spacing">
           ⚠️ Work in progress ⚠️
         </div>
       </mat-tab>
 
-      <mat-tab label="Saved Builds">
+      <mat-tab [label]="label('savedBuilds')">
         <div class="spacing">
           ⚠️ Work in progress ⚠️
         </div>
       </mat-tab>
 
-      <mat-tab label="Build Maker">
+      <mat-tab [label]="label('buildMaker')">
         <div class="spacing">
           <main-build></main-build>
         </div>

--- a/TFD-front/src/app/app.component.ts
+++ b/TFD-front/src/app/app.component.ts
@@ -13,6 +13,7 @@ import { visualStore } from './store/display.store';
 import {MatTab, MatTabGroup} from '@angular/material/tabs';
 import { trigger, transition, style, animate } from '@angular/animations';
 import {MainBuildComponent} from './build/main/main.component';
+import { getUILabel } from './lang.utils';
 
 
 @Component({
@@ -42,4 +43,8 @@ export class AppComponent {
   selectedIndex = 0;
 
   isSidebarOpen$$: Signal<boolean> = this.visual_store.isSidebarOpen
+
+  label(key: Parameters<typeof getUILabel>[1]) {
+    return getUILabel(this.visual_store.get_lang(), key);
+  }
 }

--- a/TFD-front/src/app/auth/login/login.component.html
+++ b/TFD-front/src/app/auth/login/login.component.html
@@ -1,6 +1,6 @@
 <div class="login-popup">
   @if (!this.login_store.loggedIn()) {
-    <h3>Connexion</h3>
+    <h3>{{ label('login') }}</h3>
     <language-list></language-list>
     <asl-google-signin-button
       [theme]="'outline'"
@@ -8,6 +8,6 @@
     </asl-google-signin-button>
   } @else {
     <language-list></language-list>
-    <button (click)="signOut()">Déconnexion</button>
+    <button (click)="signOut()">{{ label('logout') }}</button>
   }
 </div>

--- a/TFD-front/src/app/auth/login/login.component.ts
+++ b/TFD-front/src/app/auth/login/login.component.ts
@@ -11,6 +11,7 @@ import { MatDialogRef } from '@angular/material/dialog';
 import {initialUserData, loginStore, settingsResponse, userData} from '../../store/login.store';
 import { LanguageListComponent } from '../../langlist/language-list.component';
 import {HttpErrorResponse, HttpResourceRef} from '@angular/common/http';
+import { getUILabel } from '../../lang.utils';
 
 @Component({
   standalone: true,
@@ -54,5 +55,9 @@ export class LoginComponent implements OnInit {
 
   signOut(): void {
     this.authService.signOut();
+  }
+
+  label(key: Parameters<typeof getUILabel>[1]) {
+    return getUILabel(this.visual_store.get_lang(), key);
   }
 }

--- a/TFD-front/src/app/build/main/main.component.html
+++ b/TFD-front/src/app/build/main/main.component.html
@@ -3,16 +3,16 @@
   <section class="top-bar">
     <div>
       <button class="control" (click)="removeWeapon()">-</button>
-      <span class="label">Weapon</span>
+      <span class="label">{{ label('weapon') }}</span>
       <button class="control" (click)="addWeapon()">+</button>
     </div>
 
     <div>
       <button class="control" (click)="removeDescendant()">-</button>
-      <span class="label">Descendant</span>
+      <span class="label">{{ label('descendant') }}</span>
       <button class="control" (click)="addDescendant()">+</button>
     </div>
-    <button class="control save" (click)="saveBuild()">Save</button>
+    <button class="control save" (click)="saveBuild()">{{ label('save') }}</button>
   </section>
 
   <div class="column" *ngIf="descendants()"> <!--div descendant-->

--- a/TFD-front/src/app/build/main/main.component.ts
+++ b/TFD-front/src/app/build/main/main.component.ts
@@ -1,7 +1,9 @@
-import { Component, signal, computed } from '@angular/core';
+import { Component, signal, computed, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { WeaponBuildComponent } from '../weapon/weapon.component';
 import { DescedantBuildComponent } from '../descendant/descendant.component';
+import { visualStore } from '../../store/display.store';
+import { getUILabel } from '../../lang.utils';
 
 @Component({
   standalone: true,
@@ -11,6 +13,7 @@ import { DescedantBuildComponent } from '../descendant/descendant.component';
   styleUrls: ['./main.component.scss', '../../../styles.scss']
 })
 export class MainBuildComponent {
+  readonly visual_store = inject(visualStore);
 
   constructor() {}
 
@@ -29,5 +32,9 @@ export class MainBuildComponent {
   saveBuild() {
     // TODO: hook real persistence logic here
     console.log('Save build clicked');
+  }
+
+  label(key: Parameters<typeof getUILabel>[1]) {
+    return getUILabel(this.visual_store.get_lang(), key);
   }
 }

--- a/TFD-front/src/app/build/module/display/module-display.component.ts
+++ b/TFD-front/src/app/build/module/display/module-display.component.ts
@@ -29,8 +29,10 @@ export class ModuleComponent {
   }
 
   get name(): string {
-    const langKey = translationFieldMap[this.visual_store.get_lang()] ?? 'en';
+    const langKey = this.visual_store.get_lang() ?? 'en';
     const translation = this.get_translate(this.module.module_name_id);
-    return (translation as any)[langKey] ?? '';
+    // Guard against missing translation object or key
+    const value = (translation as any)?.[langKey];
+    return value ?? '';
   }
 }

--- a/TFD-front/src/app/build/module/display/module-display.component.ts
+++ b/TFD-front/src/app/build/module/display/module-display.component.ts
@@ -2,6 +2,8 @@ import { Component, inject, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { dataStore, defaultTranslate, TranslationString } from '../../../store/data.store';
 import { ModuleResponse } from '../../../types/module.types';
+import { visualStore } from '../../../store/display.store';
+import { translationFieldMap } from '../../../lang.utils';
 
 @Component({
   standalone: true,
@@ -14,6 +16,7 @@ export class ModuleComponent {
   constructor() {}
 
   readonly data_store = inject(dataStore);
+  readonly visual_store = inject(visualStore);
 
   @Input() module!: ModuleResponse;
 
@@ -26,6 +29,8 @@ export class ModuleComponent {
   }
 
   get name(): string {
-    return this.get_translate(this.module.module_name_id)?.fr ?? '';
+    const langKey = translationFieldMap[this.visual_store.get_lang()] ?? 'en';
+    const translation = this.get_translate(this.module.module_name_id);
+    return (translation as any)[langKey] ?? '';
   }
 }

--- a/TFD-front/src/app/build/module/display/module-display.component.ts
+++ b/TFD-front/src/app/build/module/display/module-display.component.ts
@@ -3,7 +3,7 @@ import { CommonModule } from '@angular/common';
 import { dataStore, defaultTranslate, TranslationString } from '../../../store/data.store';
 import { ModuleResponse } from '../../../types/module.types';
 import { visualStore } from '../../../store/display.store';
-import { translationFieldMap } from '../../../lang.utils';
+import { getTranslationField } from '../../../lang.utils';
 
 @Component({
   standalone: true,
@@ -29,7 +29,7 @@ export class ModuleComponent {
   }
 
   get name(): string {
-    const langKey = this.visual_store.get_lang() ?? 'en';
+    const langKey = getTranslationField(this.visual_store.get_lang());
     const translation = this.get_translate(this.module.module_name_id);
     // Guard against missing translation object or key
     const value = (translation as any)?.[langKey];

--- a/TFD-front/src/app/build/module/module.component.ts
+++ b/TFD-front/src/app/build/module/module.component.ts
@@ -2,7 +2,7 @@ import {Component, ChangeDetectorRef, inject, Input, EventEmitter, Output} from 
 import { CommonModule } from '@angular/common';
 import { selectorComponent } from '../selector/selector.component';
 import { MatDialog } from '@angular/material/dialog';
-import { dataStore, defaultTranslate, TranslationString } from '../../store/data.store';
+import { dataStore } from '../../store/data.store';
 import { ModuleComponent } from './display/module-display.component';
 import { selectorData } from '../../types/selector.types';
 import { defaultModule, ModuleResponse } from '../../types/module.types';

--- a/TFD-front/src/app/build/selector/selector.component.ts
+++ b/TFD-front/src/app/build/selector/selector.component.ts
@@ -2,7 +2,7 @@ import {Component, Inject, inject, Input} from '@angular/core';
 import { CommonModule } from '@angular/common';
 import {dataStore, defaultTranslate, TranslationString} from '../../store/data.store';
 import { visualStore } from '../../store/display.store';
-import { translationFieldMap } from '../../lang.utils';
+import { getTranslationField } from '../../lang.utils';
 import { ModuleComponent } from '../module/display/module-display.component';
 import { ReactorDisplayComponent } from '../reactor/display/reactor-display.component';
 import { ExternalDisplayComponent } from '../external/display/external-display.component';
@@ -65,7 +65,7 @@ export class selectorComponent {
 
   filteredModules() {
     return this.data_store.modulesResource.value()?.filter(module => {
-      const langKey = translationFieldMap[this.visual_store.get_lang()] ?? 'en';
+      const langKey = getTranslationField(this.visual_store.get_lang());
       const name = (this.get_translate(module.module_name_id) as any)[langKey] as string;
       const matchName = !this.searchText || name?.toLowerCase().includes(this.searchText.toLowerCase());
       const matchClass = !this.filterClass || (module.module_class_id === this.filterClass);

--- a/TFD-front/src/app/build/selector/selector.component.ts
+++ b/TFD-front/src/app/build/selector/selector.component.ts
@@ -1,6 +1,8 @@
 import {Component, Inject, inject, Input} from '@angular/core';
 import { CommonModule } from '@angular/common';
 import {dataStore, defaultTranslate, TranslationString} from '../../store/data.store';
+import { visualStore } from '../../store/display.store';
+import { translationFieldMap } from '../../lang.utils';
 import { ModuleComponent } from '../module/display/module-display.component';
 import { ReactorDisplayComponent } from '../reactor/display/reactor-display.component';
 import { ExternalDisplayComponent } from '../external/display/external-display.component';
@@ -35,6 +37,7 @@ import { ExternalComponent } from '../../types/external.types';
 })
 export class selectorComponent {
   readonly data_store = inject(dataStore);
+  readonly visual_store = inject(visualStore);
 
   filterClass: number;
   type: string = "";
@@ -62,7 +65,9 @@ export class selectorComponent {
 
   filteredModules() {
     return this.data_store.modulesResource.value()?.filter(module => {
-      const matchName = !this.searchText || this.get_translate(module.module_name_id).fr?.toLowerCase().includes(this.searchText.toLowerCase());
+      const langKey = translationFieldMap[this.visual_store.get_lang()] ?? 'en';
+      const name = (this.get_translate(module.module_name_id) as any)[langKey] as string;
+      const matchName = !this.searchText || name?.toLowerCase().includes(this.searchText.toLowerCase());
       const matchClass = !this.filterClass || (module.module_class_id === this.filterClass);
       const matchDesc = this.compareDescendantIDs(module);
       return matchName && matchClass && matchDesc;

--- a/TFD-front/src/app/lang.utils.ts
+++ b/TFD-front/src/app/lang.utils.ts
@@ -1,0 +1,54 @@
+export interface UILabels {
+  search: string;
+  savedBuilds: string;
+  buildMaker: string;
+  login: string;
+  logout: string;
+  weapon: string;
+  descendant: string;
+  save: string;
+}
+
+export const uiTranslations: Record<string, UILabels> = {
+  en: {
+    search: 'Search',
+    savedBuilds: 'Saved Builds',
+    buildMaker: 'Build Maker',
+    login: 'Login',
+    logout: 'Logout',
+    weapon: 'Weapon',
+    descendant: 'Descendant',
+    save: 'Save'
+  },
+  fr: {
+    search: 'Recherche',
+    savedBuilds: 'Builds sauvegardés',
+    buildMaker: 'Constructeur',
+    login: 'Connexion',
+    logout: 'Déconnexion',
+    weapon: 'Arme',
+    descendant: 'Descendant',
+    save: 'Sauvegarder'
+  }
+};
+
+export function getUILabel(lang: string, key: keyof UILabels): string {
+  const labels = uiTranslations[lang] ?? uiTranslations['en'];
+  return labels[key];
+}
+
+// mapping between language codes and translation string keys
+export const translationFieldMap: Record<string, string> = {
+  ko: 'ko',
+  en: 'en',
+  de: 'de',
+  ja: 'jp',
+  fr: 'fr',
+  'zh-CN': 'zh_cn',
+  'zh-TW': 'zh_tw',
+  it: 'it',
+  pl: 'pl',
+  pt: 'pt',
+  ru: 'ru',
+  es: 'es'
+};

--- a/TFD-front/src/app/lang.utils.ts
+++ b/TFD-front/src/app/lang.utils.ts
@@ -29,6 +29,106 @@ export const uiTranslations: Record<string, UILabels> = {
     weapon: 'Arme',
     descendant: 'Descendant',
     save: 'Sauvegarder'
+  },
+  ko: {
+    search: '검색',
+    savedBuilds: '저장된 빌드',
+    buildMaker: '빌드 생성기',
+    login: '로그인',
+    logout: '로그아웃',
+    weapon: '무기',
+    descendant: '디센던트',
+    save: '저장'
+  },
+  de: {
+    search: 'Suche',
+    savedBuilds: 'Gespeicherte Builds',
+    buildMaker: 'Build-Editor',
+    login: 'Anmelden',
+    logout: 'Abmelden',
+    weapon: 'Waffe',
+    descendant: 'Nachfahre',
+    save: 'Speichern'
+  },
+  ja: {
+    search: '検索',
+    savedBuilds: '保存されたビルド',
+    buildMaker: 'ビルド作成',
+    login: 'ログイン',
+    logout: 'ログアウト',
+    weapon: '武器',
+    descendant: 'ディセンダント',
+    save: '保存'
+  },
+  'zh-CN': {
+    search: '搜索',
+    savedBuilds: '已保存的构建',
+    buildMaker: '构建生成器',
+    login: '登录',
+    logout: '登出',
+    weapon: '武器',
+    descendant: '后裔',
+    save: '保存'
+  },
+  'zh-TW': {
+    search: '搜尋',
+    savedBuilds: '已儲存的構建',
+    buildMaker: '構建產生器',
+    login: '登入',
+    logout: '登出',
+    weapon: '武器',
+    descendant: '後裔',
+    save: '儲存'
+  },
+  it: {
+    search: 'Cerca',
+    savedBuilds: 'Build Salvate',
+    buildMaker: 'Creatore di Build',
+    login: 'Accedi',
+    logout: 'Disconnetti',
+    weapon: 'Arma',
+    descendant: 'Discendente',
+    save: 'Salva'
+  },
+  pl: {
+    search: 'Szukaj',
+    savedBuilds: 'Zapisane Buildy',
+    buildMaker: 'Kreator Buildów',
+    login: 'Zaloguj',
+    logout: 'Wyloguj',
+    weapon: 'Broń',
+    descendant: 'Potomek',
+    save: 'Zapisz'
+  },
+  pt: {
+    search: 'Buscar',
+    savedBuilds: 'Builds Salvos',
+    buildMaker: 'Construtor de Build',
+    login: 'Entrar',
+    logout: 'Sair',
+    weapon: 'Arma',
+    descendant: 'Descendente',
+    save: 'Salvar'
+  },
+  ru: {
+    search: 'Поиск',
+    savedBuilds: 'Сохранённые сборки',
+    buildMaker: 'Создатель сборки',
+    login: 'Войти',
+    logout: 'Выйти',
+    weapon: 'Оружие',
+    descendant: 'Наследник',
+    save: 'Сохранить'
+  },
+  es: {
+    search: 'Buscar',
+    savedBuilds: 'Construcciones guardadas',
+    buildMaker: 'Creador de Builds',
+    login: 'Iniciar sesión',
+    logout: 'Cerrar sesión',
+    weapon: 'Arma',
+    descendant: 'Descendiente',
+    save: 'Guardar'
   }
 };
 
@@ -37,18 +137,25 @@ export function getUILabel(lang: string, key: keyof UILabels): string {
   return labels[key];
 }
 
-// mapping between language codes and translation string keys
-export const translationFieldMap: Record<string, string> = {
-  ko: 'ko',
-  en: 'en',
-  de: 'de',
-  ja: 'jp',
-  fr: 'fr',
-  'zh-CN': 'zh_cn',
-  'zh-TW': 'zh_tw',
-  it: 'it',
-  pl: 'pl',
-  pt: 'pt',
-  ru: 'ru',
-  es: 'es'
-};
+export function getTranslationField(lang: string): string {
+  switch (lang) {
+    case 'ko':
+    case 'en':
+    case 'de':
+    case 'fr':
+    case 'it':
+    case 'pl':
+    case 'pt':
+    case 'ru':
+    case 'es':
+      return lang;
+    case 'ja':
+      return 'jp';
+    case 'zh-CN':
+      return 'zh_cn';
+    case 'zh-TW':
+      return 'zh_tw';
+    default:
+      return 'en';
+  }
+}

--- a/TFD-front/src/app/langlist/language-list.component.ts
+++ b/TFD-front/src/app/langlist/language-list.component.ts
@@ -12,11 +12,13 @@ import { loginStore } from '../store/login.store';
 })
 export class LanguageListComponent implements OnInit {
   readonly login_store = inject(loginStore);
+  readonly visual_store = inject(visualStore);
 
   selectedLanguage: string = "";
 
   ngOnInit(): void {
     this.selectedLanguage = this.login_store.settings().settings;
+    this.visual_store.set_lang(this.selectedLanguage);
   }
 
   // supported languages
@@ -37,6 +39,7 @@ export class LanguageListComponent implements OnInit {
 
   onLanguageChange(selectedCode: string): void {
     this.selectedLanguage = selectedCode;
+    this.visual_store.set_lang(selectedCode);
     this.login_store.load_UpdateSettings(selectedCode);
   }
 }

--- a/TFD-front/src/app/store/login.store.ts
+++ b/TFD-front/src/app/store/login.store.ts
@@ -3,6 +3,9 @@ import {signalStore, withState, withMethods, withProps, patchState} from '@ngrx/
 import { httpResource } from "@angular/common/http";
 import { environment } from '../../env/environment';
 import { SocialUser } from '@abacritt/angularx-social-login';
+import { visualStore } from './display.store';
+
+const display = inject(visualStore);
 
 export type settingsResponse = {
   settings: string,
@@ -95,6 +98,7 @@ export const loginStore = signalStore(
             ...store.userSettings_Resource.value()
           }
         });
+        display.set_lang(store.userSettings_Resource.value().settings);
       }
     },
     load_UpdateSettings: (lang: string) => {
@@ -105,6 +109,7 @@ export const loginStore = signalStore(
         },
         _updateSettingsResourceEnabled: true
       });
+      display.set_lang(lang);
       store.updateSettings_Resource.reload()
     },
     refresh_UserSettings: () => store.userSettings_Resource.reload(),

--- a/TFD-front/src/app/store/login.store.ts
+++ b/TFD-front/src/app/store/login.store.ts
@@ -5,8 +5,6 @@ import { environment } from '../../env/environment';
 import { SocialUser } from '@abacritt/angularx-social-login';
 import { visualStore } from './display.store';
 
-const display = inject(visualStore);
-
 export type settingsResponse = {
   settings: string,
   success: boolean
@@ -53,31 +51,32 @@ export const loginStore = signalStore(
   },
   withState<loginStore>(initialState),
   withProps((store) => ({
-      userSettings_Resource: httpResource<settingsResponse | undefined>(() =>
-        store._userSettingsResourceEnabled()
-          ? {
-            url: `${environment.apiBaseUrl}/user_settings`,
-            method: 'POST',
-            body: {
-              id: store.user()?.id ?? '',
-              email: store.user()?.email ?? '',
-              name: store.user()?.name ?? '',
-              photoUrl: store.user()?.photoUrl ?? '',
-            },
-            withCredentials: true,
-            transferCache: true,
-          }
-          : undefined),
-      updateSettings_Resource: httpResource<settingsResponse | undefined> (() =>
-        store._updateSettingsResourceEnabled()
-          ? {
-            url: `${environment.apiBaseUrl}/set_settings`,
-            method: 'POST',
-            body: { id: store.user()?.id,   lang: store.settings()?.settings },
-            withCredentials: true,
-            transferCache: true,
-          }
-          : undefined),
+    display: inject(visualStore),
+    userSettings_Resource: httpResource<settingsResponse | undefined>(() =>
+      store._userSettingsResourceEnabled()
+        ? {
+          url: `${environment.apiBaseUrl}/user_settings`,
+          method: 'POST',
+          body: {
+            id: store.user()?.id ?? '',
+            email: store.user()?.email ?? '',
+            name: store.user()?.name ?? '',
+            photoUrl: store.user()?.photoUrl ?? '',
+          },
+          withCredentials: true,
+          transferCache: true,
+        }
+        : undefined),
+    updateSettings_Resource: httpResource<settingsResponse | undefined> (() =>
+      store._updateSettingsResourceEnabled()
+        ? {
+          url: `${environment.apiBaseUrl}/set_settings`,
+          method: 'POST',
+          body: { id: store.user()?.id,   lang: store.settings()?.settings },
+          withCredentials: true,
+          transferCache: true,
+        }
+        : undefined),
   })),
   withMethods((store) => ({
     setLoginState: (log: SocialUser | undefined) => {
@@ -98,7 +97,7 @@ export const loginStore = signalStore(
             ...store.userSettings_Resource.value()
           }
         });
-        display.set_lang(store.userSettings_Resource.value().settings);
+        store.display.set_lang(store.userSettings_Resource.value().settings);
       }
     },
     load_UpdateSettings: (lang: string) => {
@@ -109,7 +108,7 @@ export const loginStore = signalStore(
         },
         _updateSettingsResourceEnabled: true
       });
-      display.set_lang(lang);
+      store.display.set_lang(lang);
       store.updateSettings_Resource.reload()
     },
     refresh_UserSettings: () => store.userSettings_Resource.reload(),


### PR DESCRIPTION
## Summary
- add utility for UI translations and translation field mapping
- sync language choice with `visualStore`
- apply language labels on tabs, login dialog, and build components
- fetch module names using current language

## Testing
- `npm run build` *(fails: Could not resolve ./env/client_secret.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841a1ec3bf483208686874887046f30