### PR TITLE
Expand agent instructions

### DIFF
--- a/AGENT.MD
+++ b/AGENT.MD
@@ -49,3 +49,9 @@ commits should be prototyped as follow: `short: {message related}`
 
 ## File/Folder Structure
 See the sub-AGENT.MD files for detailed breakdowns for each layer. and keep in mind the previous ones
+
+## Data Flow
+1. Frontend stores use `httpResource` to call API endpoints.
+2. Flask routes forward the request to CRUD modules under `api/sql`.
+3. CRUD modules execute stored procedures to read or write data.
+4. Results are returned as JSON back to the stores via the API.

--- a/TFD-front/AGENT.MD
+++ b/TFD-front/AGENT.MD
@@ -32,7 +32,8 @@ TFD-front/
 - Signal stores pattern (see `store/*.ts`)
 - Use modern Angular patterns (signals over observables)
 - All user-facing strings should be translatable (i18n ready)
-- All API calls use Angular HttpClient, endpoints from environment config
+- HTTP requests must be defined as `httpResource` objects inside stores.
+- Do **not** inject `HttpClient` directly anywhere else.
 
 ## Development
 - Use `ng serve` for local dev (`http://localhost:4200`)
@@ -44,7 +45,17 @@ TFD-front/
 - Always use explicit typing
 - Follow Angular CLI scaffolding for new components
 - Use `environment.ts`/`environment.prod.ts` for switching API endpoints
-- **DO NOT USE** httpclient use httpResources directly inside stores
+- Declare all interfaces and custom types in a file within `src/app/types`
+  (create a new one if needed)
+
+## Patterns
+- Each store is created with `signalStore` using `withState`, `withProps` and
+  `withMethods`.
+- HTTP calls are defined as `httpResource` properties inside stores and
+  triggered via `.reload()`.
+- Default objects like `defaultModule` or `defaultWeapon` initialize state to
+  avoid undefined values.
+- API base URLs come from the environment files.
 
 ## PR/Commit Guidelines
 - All commit / PR messages / branch name in English

--- a/api/AGENT.MD
+++ b/api/AGENT.MD
@@ -34,6 +34,13 @@ api/
 - All migrations via Alembic (versions tracked in `sql/alembic/versions/`)
 - ORM models are strictly typed (see `sql/model.py`)
 
+## Patterns
+- Routes return JSON using `app.response_class` with `json.dumps(..., ensure_ascii=False)`.
+- Data access is performed via modules in `sql/CRUD`.
+- Each CRUD function calls a stored procedure defined in the database.
+- Writing raw SQL queries directly in these modules is forbidden.
+- Long running imports launch a `threading.Thread` from `fillroutes/full.py`.
+
 ## Development
 - Use `gunicorn` for prod, `flask run` for debug only
 - Dedicated user (`appuser`) for Docker container, never run as root

--- a/api/sql/AGENT.MD
+++ b/api/sql/AGENT.MD
@@ -34,6 +34,12 @@ sql/
 - Data fetched from remote JSON APIs is normalized before DB insert
 - All importers should handle upserts to avoid duplicates
 
+## Patterns
+- Each entity has a dedicated CRUD module under `sql/CRUD`.
+- Models are declared in `model.py` and reused across migrations and CRUD.
+- Alembic migrations live in `alembic/versions` with descriptive filenames.
+- CRUD modules execute stored procedures rather than inline SQL queries.
+
 ## PR/Commit Guidelines
 - PRs must document schema changes
 - All comments/messages in English


### PR DESCRIPTION
## Summary
- describe how data flows from store to database in `AGENT.MD`
- clarify httpResource usage and types folder in frontend instructions
- enforce stored procedure usage in API docs

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6849d45b9b88832085869dba9ca2ed26