### PR TITLE
Implement build load sync

### DIFF
--- a/TFD-front/src/app/app.component.html
+++ b/TFD-front/src/app/app.component.html
@@ -1,7 +1,7 @@
 <div class="container">
   <sidebar></sidebar>
   <div class="tabs sidebar-small">
-    <mat-tab-group [(selectedIndex)]="selectedIndex">
+    <mat-tab-group [(selectedIndex)]="selectedIndex" (selectedIndexChange)="onTabChange($event)">
       <mat-tab [label]="label('search')">
         <div class="spacing">
           ⚠️ Work in progress ⚠️

--- a/TFD-front/src/app/app.component.html
+++ b/TFD-front/src/app/app.component.html
@@ -3,9 +3,7 @@
   <div class="tabs sidebar-small">
     <mat-tab-group [(selectedIndex)]="selectedIndex" (selectedIndexChange)="onTabChange($event)">
       <mat-tab [label]="label('search')">
-        <div class="spacing">
-          ⚠️ Work in progress ⚠️
-        </div>
+        <search-tab></search-tab>
       </mat-tab>
 
       <mat-tab [label]="label('savedBuilds')">

--- a/TFD-front/src/app/app.component.ts
+++ b/TFD-front/src/app/app.component.ts
@@ -14,6 +14,7 @@ import {MatTab, MatTabGroup} from '@angular/material/tabs';
 import { trigger, transition, style, animate } from '@angular/animations';
 import {MainBuildComponent} from './build/main/main.component';
 import { SavedBuildsListComponent } from './build/saved/saved-builds.component';
+import { SearchComponent } from './search/search.component';
 import { getUILabel } from './lang.utils';
 import { Router, NavigationEnd } from '@angular/router';
 import { filter } from 'rxjs';
@@ -21,7 +22,16 @@ import { filter } from 'rxjs';
 
 
 @Component({
-  imports: [CommonModule, FormsModule, sidebarComponent, MatTab, MatTabGroup, MainBuildComponent, SavedBuildsListComponent],
+  imports: [
+    CommonModule,
+    FormsModule,
+    sidebarComponent,
+    MatTab,
+    MatTabGroup,
+    MainBuildComponent,
+    SavedBuildsListComponent,
+    SearchComponent
+  ],
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss'],
@@ -59,7 +69,8 @@ export class AppComponent {
   }
 
   onTabChange(index: number) {
-    const route = index === 1 ? '/my-builds' : index === 2 ? '/build-maker' : '/';
+    const route =
+      index === 1 ? '/my-builds' : index === 2 ? '/build-maker' : '/search';
     this.router.navigateByUrl(route);
   }
 

--- a/TFD-front/src/app/app.component.ts
+++ b/TFD-front/src/app/app.component.ts
@@ -15,6 +15,8 @@ import { trigger, transition, style, animate } from '@angular/animations';
 import {MainBuildComponent} from './build/main/main.component';
 import { SavedBuildsListComponent } from './build/saved/saved-builds.component';
 import { getUILabel } from './lang.utils';
+import { Router, NavigationEnd } from '@angular/router';
+import { filter } from 'rxjs';
 
 
 
@@ -39,12 +41,37 @@ import { getUILabel } from './lang.utils';
 export class AppComponent {
   readonly data_store = inject(dataStore);
   readonly visual_store = inject(visualStore);
+  private router = inject(Router);
 
   title = 'TFD-front';
 
   selectedIndex = 0;
 
   isSidebarOpen$$: Signal<boolean> = this.visual_store.isSidebarOpen
+
+  constructor() {
+    this.updateIndexFromUrl(this.router.url);
+    this.router.events
+      .pipe(filter(event => event instanceof NavigationEnd))
+      .subscribe((event) => {
+        this.updateIndexFromUrl((event as NavigationEnd).urlAfterRedirects);
+      });
+  }
+
+  onTabChange(index: number) {
+    const route = index === 1 ? '/my-builds' : index === 2 ? '/build-maker' : '/';
+    this.router.navigateByUrl(route);
+  }
+
+  private updateIndexFromUrl(url: string) {
+    if (url.startsWith('/my-builds')) {
+      this.selectedIndex = 1;
+    } else if (url.startsWith('/build-maker')) {
+      this.selectedIndex = 2;
+    } else {
+      this.selectedIndex = 0;
+    }
+  }
 
   label(key: Parameters<typeof getUILabel>[1]) {
     return getUILabel(this.visual_store.get_lang(), key);

--- a/TFD-front/src/app/app.routes.ts
+++ b/TFD-front/src/app/app.routes.ts
@@ -2,6 +2,10 @@ import { Routes } from '@angular/router';
 
 export const routes: Routes = [
   {
+    path: 'search',
+    loadComponent: () => import('./search/search.component').then(c => c.SearchComponent)
+  },
+  {
     path: 'my-builds',
     loadComponent: () =>
       import('./build/saved/saved-builds.component').then(m => m.SavedBuildsListComponent),
@@ -13,7 +17,7 @@ export const routes: Routes = [
   },
   {
     path: '',
-    redirectTo: 'build-maker',
+    redirectTo: 'search',
     pathMatch: 'full'
   }
 ];

--- a/TFD-front/src/app/build/descendant/descendant.component.ts
+++ b/TFD-front/src/app/build/descendant/descendant.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject } from '@angular/core';
+import { Component, inject, effect } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ModuleBuildComponent } from '../module/module.component';
 import { ReactorBuildComponent } from '../reactor/reactor.component';
@@ -28,6 +28,9 @@ import { buildStore } from '../../store/build.store';
 export class DescedantBuildComponent {
   readonly data_store = inject(dataStore);
   readonly build_store = inject(buildStore);
+  readonly _syncEffect = effect(() => {
+    this.module_data.descendant = this.build_store.descendant().descendant_id;
+  });
 
   module_data: selectorData = {
     selectitems: "modules",

--- a/TFD-front/src/app/build/main/main.component.html
+++ b/TFD-front/src/app/build/main/main.component.html
@@ -13,7 +13,7 @@
       <button class="control" (click)="addDescendant()">+</button>
     </div>
     <div>
-      <input type="text" [(ngModel)]="buildName" placeholder="Build Name" class="build-name-input"/>
+      <input type="text" [(ngModel)]="buildName" [placeholder]="label('buildNamePlaceholder')" class="build-name-input"/>
       <button class="control save" (click)="saveBuild()">{{ label('save') }}</button>
     </div>
   </section>

--- a/TFD-front/src/app/build/main/main.component.ts
+++ b/TFD-front/src/app/build/main/main.component.ts
@@ -92,6 +92,7 @@ export class MainBuildComponent implements OnInit {
   }
 
   ngOnInit(): void {
+    this.data_store.load_all();
     this.route.queryParamMap.subscribe(params => {
       const idParam = params.get('build');
       if (idParam) {

--- a/TFD-front/src/app/build/saved/saved-builds.component.html
+++ b/TFD-front/src/app/build/saved/saved-builds.component.html
@@ -1,18 +1,18 @@
 <div class="saved-builds-container">
 
   <div *ngIf="isLoading()" class="loading-indicator">
-    <p>Loading builds...</p>
+    <p>{{ label('loadingBuilds') }}</p>
   </div>
 
   <div *ngIf="errorLoading()" class="error-message">
-    <p>Error: {{ errorLoading() }}</p>
+    <p>{{ label('errorLoadingBuilds') }}: {{ errorLoading() }}</p>
   </div>
 
   <div *ngIf="!isLoading() && !errorLoading() && builds().length === 0" class="no-builds">
-    <p>🔒 no build Yet login and create your first one</p>
+    <p>🔒 {{ label('noBuilds') }}</p>
   </div>
 
-  <button (click)="refresh()"> refresh </button>
+  <button (click)="refresh()">{{ label('refresh') }}</button>
 
   <div *ngIf="!isLoading() && !errorLoading() && builds().length > 0" class="builds-grid">
     @for (build of builds(); track build.build_id) {

--- a/TFD-front/src/app/build/saved/saved-builds.component.ts
+++ b/TFD-front/src/app/build/saved/saved-builds.component.ts
@@ -1,17 +1,9 @@
 import { Component, inject, signal, WritableSignal, effect } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { loginStore } from '../../store/login.store';
-import { buildStore } from '../../store/build.store';
 import { BuildCardComponent, BuildSummary } from './build-card/build-card.component';
-import { environment } from '../../../env/environment';
 import { Router } from '@angular/router';
 import { buildListStore } from '../../store/build-list.store';
-import { dataStore } from '../../store/data.store';
-import { defaultDescendants } from '../../types/descendant.types';
-import { defaultModule } from '../../types/module.types';
-import { defaultWeapon } from '../../types/weapon.types';
-import { defaultReactor } from '../../types/reactor.types';
-import { defaultExternalComponent } from '../../types/external.types';
 
 @Component({
   selector: 'saved-builds-list',
@@ -22,9 +14,7 @@ import { defaultExternalComponent } from '../../types/external.types';
 export class SavedBuildsListComponent {
   private buildListStore = inject(buildListStore)
   private loginStore = inject(loginStore);
-  private buildStore = inject(buildStore);
-  private dataStore = inject(dataStore)
-  //private router = inject(Router); // TODO: not use full now
+  private router = inject(Router);
 
   builds: WritableSignal<BuildSummary[]> = signal([]);
   isLoading = signal(false);
@@ -41,26 +31,6 @@ export class SavedBuildsListComponent {
     });
 
     effect(() => {
-      if (this.buildStore.getBuildRessource.hasValue()) {
-        const build = this.buildStore.getBuildRessource.value()!.build_data;
-        const data = {
-          descendant: this.dataStore.descendantResource.value()?.find(item => item.descendant_id === build.descendant) ?? defaultDescendants,
-          descendantModules: build.descendantModules.map(id => this.dataStore.modulesResource.value()?.find(item => item.module_id === id) ?? defaultModule),
-          weapons: build.weapons.map(id => this.dataStore.weaponResource.value()?.find(w => w.weapon_id === id) ?? defaultWeapon),
-          weaponsModules: build.weaponsModules.map(slot => slot.map(id => this.dataStore.modulesResource.value()?.find(m => m.module_id === id) ?? defaultModule)),
-          reactor: this.dataStore.reactorResource.value()?.find(item => item.reactor_id === build.reactor) ?? defaultReactor,
-          externals: build.externals.map(id => this.dataStore.externalResource.value()?.find(e => e.external_component_id === id) ?? defaultExternalComponent),
-        };
-        console.log(data, build, this.dataStore.descendantResource.value())
-        this.buildStore.hydrate(data);
-
-        //TODO: update (this.module_data.descendant = res.descendant_id)
-        //TODO: update (weapon number to display + descendant to display)
-        //TODO: navigate to the build Maker Tab
-      }
-    });
-
-    effect(() => {
       if (this.buildListStore.resource.hasValue()) {
         this.builds.set(this.buildListStore.resource.value());
       }
@@ -68,7 +38,7 @@ export class SavedBuildsListComponent {
   }
 
   LoadBuild(buildId: number): void {
-    this.buildStore.loadFromApi(buildId);
+    this.router.navigate(['/build-maker'], { queryParams: { build: buildId } });
   }
 
   refresh(): void {

--- a/TFD-front/src/app/build/saved/saved-builds.component.ts
+++ b/TFD-front/src/app/build/saved/saved-builds.component.ts
@@ -4,6 +4,8 @@ import { loginStore } from '../../store/login.store';
 import { BuildCardComponent, BuildSummary } from './build-card/build-card.component';
 import { Router } from '@angular/router';
 import { buildListStore } from '../../store/build-list.store';
+import { visualStore } from '../../store/display.store';
+import { getUILabel } from '../../lang.utils';
 
 @Component({
   selector: 'saved-builds-list',
@@ -15,6 +17,7 @@ export class SavedBuildsListComponent {
   private buildListStore = inject(buildListStore)
   private loginStore = inject(loginStore);
   private router = inject(Router);
+  private visualStore = inject(visualStore);
 
   builds: WritableSignal<BuildSummary[]> = signal([]);
   isLoading = signal(false);
@@ -43,5 +46,9 @@ export class SavedBuildsListComponent {
 
   refresh(): void {
     this.buildListStore.resource.reload()
+  }
+
+  label(key: Parameters<typeof getUILabel>[1]) {
+    return getUILabel(this.visualStore.get_lang(), key);
   }
 }

--- a/TFD-front/src/app/build/selector/selector.component.ts
+++ b/TFD-front/src/app/build/selector/selector.component.ts
@@ -103,25 +103,7 @@ export class selectorComponent {
     private dialogRef: MatDialogRef<selectorComponent>) {
     this.filterClass = data.filterClass ?? 0;
     this.type = data.selectitems;
-    // dont load twice if values are load
-    if (!this.data_store.modulesResource.hasValue()) {
-      this.data_store.load_modules()
-    }
-    if (!this.data_store.translationResource.hasValue()) {
-      this.data_store.load_translations()
-    }
-    if (!this.data_store.descendantResource.hasValue()) {
-      this.data_store.load_descendants()
-    }
-    if (!this.data_store.weaponResource.hasValue()) {
-      this.data_store.load_weapons()
-    }
-    if (!this.data_store.reactorResource.hasValue()) {
-      this.data_store.load_reactors()
-    }
-    if (!this.data_store.externalResource.hasValue()) {
-      this.data_store.load_externals()
-    }
+    // resources are preloaded in main component
   }
 
   selectModules(module: ModuleResponse): void {

--- a/TFD-front/src/app/lang.utils.ts
+++ b/TFD-front/src/app/lang.utils.ts
@@ -7,6 +7,12 @@ export interface UILabels {
   weapon: string;
   descendant: string;
   save: string;
+  buildNamePlaceholder: string;
+  loadingBuilds: string;
+  errorLoadingBuilds: string;
+  noBuilds: string;
+  refresh: string;
+  wipMessage: string;
 }
 
 export const uiTranslations: Record<string, UILabels> = {
@@ -18,7 +24,13 @@ export const uiTranslations: Record<string, UILabels> = {
     logout: 'Logout',
     weapon: 'Weapon',
     descendant: 'Descendant',
-    save: 'Save'
+    save: 'Save',
+    buildNamePlaceholder: 'Build Name',
+    loadingBuilds: 'Loading builds...',
+    errorLoadingBuilds: 'Error loading builds',
+    noBuilds: 'No builds found',
+    refresh: 'Refresh',
+    wipMessage: 'Work in progress'
   },
   fr: {
     search: 'Recherche',
@@ -28,7 +40,13 @@ export const uiTranslations: Record<string, UILabels> = {
     logout: 'Déconnexion',
     weapon: 'Arme',
     descendant: 'Descendant',
-    save: 'Sauvegarder'
+    save: 'Sauvegarder',
+    buildNamePlaceholder: 'Nom du build',
+    loadingBuilds: 'Chargement des builds...',
+    errorLoadingBuilds: "Erreur lors du chargement des builds",
+    noBuilds: 'Aucun build disponible',
+    refresh: 'Rafraîchir',
+    wipMessage: 'Travail en cours'
   },
   ko: {
     search: '검색',
@@ -38,7 +56,13 @@ export const uiTranslations: Record<string, UILabels> = {
     logout: '로그아웃',
     weapon: '무기',
     descendant: '디센던트',
-    save: '저장'
+    save: '저장',
+    buildNamePlaceholder: 'Build Name',
+    loadingBuilds: 'Loading builds...',
+    errorLoadingBuilds: 'Error loading builds',
+    noBuilds: 'No builds found',
+    refresh: 'Refresh',
+    wipMessage: 'Work in progress'
   },
   de: {
     search: 'Suche',
@@ -48,7 +72,13 @@ export const uiTranslations: Record<string, UILabels> = {
     logout: 'Abmelden',
     weapon: 'Waffe',
     descendant: 'Nachfahre',
-    save: 'Speichern'
+    save: 'Speichern',
+    buildNamePlaceholder: 'Build Name',
+    loadingBuilds: 'Loading builds...',
+    errorLoadingBuilds: 'Error loading builds',
+    noBuilds: 'No builds found',
+    refresh: 'Refresh',
+    wipMessage: 'Work in progress'
   },
   ja: {
     search: '検索',
@@ -58,7 +88,13 @@ export const uiTranslations: Record<string, UILabels> = {
     logout: 'ログアウト',
     weapon: '武器',
     descendant: 'ディセンダント',
-    save: '保存'
+    save: '保存',
+    buildNamePlaceholder: 'Build Name',
+    loadingBuilds: 'Loading builds...',
+    errorLoadingBuilds: 'Error loading builds',
+    noBuilds: 'No builds found',
+    refresh: 'Refresh',
+    wipMessage: 'Work in progress'
   },
   'zh-CN': {
     search: '搜索',
@@ -68,7 +104,13 @@ export const uiTranslations: Record<string, UILabels> = {
     logout: '登出',
     weapon: '武器',
     descendant: '后裔',
-    save: '保存'
+    save: '保存',
+    buildNamePlaceholder: 'Build Name',
+    loadingBuilds: 'Loading builds...',
+    errorLoadingBuilds: 'Error loading builds',
+    noBuilds: 'No builds found',
+    refresh: 'Refresh',
+    wipMessage: 'Work in progress'
   },
   'zh-TW': {
     search: '搜尋',
@@ -78,7 +120,13 @@ export const uiTranslations: Record<string, UILabels> = {
     logout: '登出',
     weapon: '武器',
     descendant: '後裔',
-    save: '儲存'
+    save: '儲存',
+    buildNamePlaceholder: 'Build Name',
+    loadingBuilds: 'Loading builds...',
+    errorLoadingBuilds: 'Error loading builds',
+    noBuilds: 'No builds found',
+    refresh: 'Refresh',
+    wipMessage: 'Work in progress'
   },
   it: {
     search: 'Cerca',
@@ -88,7 +136,13 @@ export const uiTranslations: Record<string, UILabels> = {
     logout: 'Disconnetti',
     weapon: 'Arma',
     descendant: 'Discendente',
-    save: 'Salva'
+    save: 'Salva',
+    buildNamePlaceholder: 'Build Name',
+    loadingBuilds: 'Loading builds...',
+    errorLoadingBuilds: 'Error loading builds',
+    noBuilds: 'No builds found',
+    refresh: 'Refresh',
+    wipMessage: 'Work in progress'
   },
   pl: {
     search: 'Szukaj',
@@ -98,7 +152,13 @@ export const uiTranslations: Record<string, UILabels> = {
     logout: 'Wyloguj',
     weapon: 'Broń',
     descendant: 'Potomek',
-    save: 'Zapisz'
+    save: 'Zapisz',
+    buildNamePlaceholder: 'Build Name',
+    loadingBuilds: 'Loading builds...',
+    errorLoadingBuilds: 'Error loading builds',
+    noBuilds: 'No builds found',
+    refresh: 'Refresh',
+    wipMessage: 'Work in progress'
   },
   pt: {
     search: 'Buscar',
@@ -108,7 +168,13 @@ export const uiTranslations: Record<string, UILabels> = {
     logout: 'Sair',
     weapon: 'Arma',
     descendant: 'Descendente',
-    save: 'Salvar'
+    save: 'Salvar',
+    buildNamePlaceholder: 'Build Name',
+    loadingBuilds: 'Loading builds...',
+    errorLoadingBuilds: 'Error loading builds',
+    noBuilds: 'No builds found',
+    refresh: 'Refresh',
+    wipMessage: 'Work in progress'
   },
   ru: {
     search: 'Поиск',
@@ -118,7 +184,13 @@ export const uiTranslations: Record<string, UILabels> = {
     logout: 'Выйти',
     weapon: 'Оружие',
     descendant: 'Наследник',
-    save: 'Сохранить'
+    save: 'Сохранить',
+    buildNamePlaceholder: 'Build Name',
+    loadingBuilds: 'Loading builds...',
+    errorLoadingBuilds: 'Error loading builds',
+    noBuilds: 'No builds found',
+    refresh: 'Refresh',
+    wipMessage: 'Work in progress'
   },
   es: {
     search: 'Buscar',
@@ -128,7 +200,13 @@ export const uiTranslations: Record<string, UILabels> = {
     logout: 'Cerrar sesión',
     weapon: 'Arma',
     descendant: 'Descendiente',
-    save: 'Guardar'
+    save: 'Guardar',
+    buildNamePlaceholder: 'Build Name',
+    loadingBuilds: 'Loading builds...',
+    errorLoadingBuilds: 'Error loading builds',
+    noBuilds: 'No builds found',
+    refresh: 'Refresh',
+    wipMessage: 'Work in progress'
   }
 };
 

--- a/TFD-front/src/app/lang.utils.ts
+++ b/TFD-front/src/app/lang.utils.ts
@@ -57,12 +57,12 @@ export const uiTranslations: Record<string, UILabels> = {
     weapon: '무기',
     descendant: '디센던트',
     save: '저장',
-    buildNamePlaceholder: 'Build Name',
-    loadingBuilds: 'Loading builds...',
-    errorLoadingBuilds: 'Error loading builds',
-    noBuilds: 'No builds found',
-    refresh: 'Refresh',
-    wipMessage: 'Work in progress'
+    buildNamePlaceholder: '빌드 이름',
+    loadingBuilds: '빌드 불러오는 중...',
+    errorLoadingBuilds: '빌드를 불러오는 데 오류 발생',
+    noBuilds: '저장된 빌드가 없습니다',
+    refresh: '새로고침',
+    wipMessage: '작업 진행 중'
   },
   de: {
     search: 'Suche',
@@ -73,12 +73,12 @@ export const uiTranslations: Record<string, UILabels> = {
     weapon: 'Waffe',
     descendant: 'Nachfahre',
     save: 'Speichern',
-    buildNamePlaceholder: 'Build Name',
-    loadingBuilds: 'Loading builds...',
-    errorLoadingBuilds: 'Error loading builds',
-    noBuilds: 'No builds found',
-    refresh: 'Refresh',
-    wipMessage: 'Work in progress'
+    buildNamePlaceholder: 'Build-Name',
+    loadingBuilds: 'Builds werden geladen...',
+    errorLoadingBuilds: 'Fehler beim Laden der Builds',
+    noBuilds: 'Keine Builds gefunden',
+    refresh: 'Aktualisieren',
+    wipMessage: 'In Arbeit'
   },
   ja: {
     search: '検索',
@@ -89,12 +89,12 @@ export const uiTranslations: Record<string, UILabels> = {
     weapon: '武器',
     descendant: 'ディセンダント',
     save: '保存',
-    buildNamePlaceholder: 'Build Name',
-    loadingBuilds: 'Loading builds...',
-    errorLoadingBuilds: 'Error loading builds',
-    noBuilds: 'No builds found',
-    refresh: 'Refresh',
-    wipMessage: 'Work in progress'
+    buildNamePlaceholder: 'ビルド名',
+    loadingBuilds: 'ビルドを読み込み中...',
+    errorLoadingBuilds: 'ビルドの読み込みエラー',
+    noBuilds: 'ビルドが見つかりません',
+    refresh: '更新',
+    wipMessage: '作業中'
   },
   'zh-CN': {
     search: '搜索',
@@ -105,12 +105,12 @@ export const uiTranslations: Record<string, UILabels> = {
     weapon: '武器',
     descendant: '后裔',
     save: '保存',
-    buildNamePlaceholder: 'Build Name',
-    loadingBuilds: 'Loading builds...',
-    errorLoadingBuilds: 'Error loading builds',
-    noBuilds: 'No builds found',
-    refresh: 'Refresh',
-    wipMessage: 'Work in progress'
+    buildNamePlaceholder: '构建名称',
+    loadingBuilds: '正在加载构建...',
+    errorLoadingBuilds: '加载构建时出错',
+    noBuilds: '没有找到构建',
+    refresh: '刷新',
+    wipMessage: '开发中'
   },
   'zh-TW': {
     search: '搜尋',
@@ -121,12 +121,12 @@ export const uiTranslations: Record<string, UILabels> = {
     weapon: '武器',
     descendant: '後裔',
     save: '儲存',
-    buildNamePlaceholder: 'Build Name',
-    loadingBuilds: 'Loading builds...',
-    errorLoadingBuilds: 'Error loading builds',
-    noBuilds: 'No builds found',
-    refresh: 'Refresh',
-    wipMessage: 'Work in progress'
+    buildNamePlaceholder: '構建名稱',
+    loadingBuilds: '載入構建中...',
+    errorLoadingBuilds: '載入構建時出錯',
+    noBuilds: '沒有找到構建',
+    refresh: '重新整理',
+    wipMessage: '開發中'
   },
   it: {
     search: 'Cerca',
@@ -137,12 +137,12 @@ export const uiTranslations: Record<string, UILabels> = {
     weapon: 'Arma',
     descendant: 'Discendente',
     save: 'Salva',
-    buildNamePlaceholder: 'Build Name',
-    loadingBuilds: 'Loading builds...',
-    errorLoadingBuilds: 'Error loading builds',
-    noBuilds: 'No builds found',
-    refresh: 'Refresh',
-    wipMessage: 'Work in progress'
+    buildNamePlaceholder: 'Nome build',
+    loadingBuilds: 'Caricamento build...',
+    errorLoadingBuilds: 'Errore nel caricamento delle build',
+    noBuilds: 'Nessuna build trovata',
+    refresh: 'Aggiorna',
+    wipMessage: 'Lavori in corso'
   },
   pl: {
     search: 'Szukaj',
@@ -153,12 +153,12 @@ export const uiTranslations: Record<string, UILabels> = {
     weapon: 'Broń',
     descendant: 'Potomek',
     save: 'Zapisz',
-    buildNamePlaceholder: 'Build Name',
-    loadingBuilds: 'Loading builds...',
-    errorLoadingBuilds: 'Error loading builds',
-    noBuilds: 'No builds found',
-    refresh: 'Refresh',
-    wipMessage: 'Work in progress'
+    buildNamePlaceholder: 'Nazwa builda',
+    loadingBuilds: 'Ładowanie buildów...',
+    errorLoadingBuilds: 'Błąd ładowania buildów',
+    noBuilds: 'Brak zapisanych buildów',
+    refresh: 'Odśwież',
+    wipMessage: 'Prace w toku'
   },
   pt: {
     search: 'Buscar',
@@ -169,12 +169,12 @@ export const uiTranslations: Record<string, UILabels> = {
     weapon: 'Arma',
     descendant: 'Descendente',
     save: 'Salvar',
-    buildNamePlaceholder: 'Build Name',
-    loadingBuilds: 'Loading builds...',
-    errorLoadingBuilds: 'Error loading builds',
-    noBuilds: 'No builds found',
-    refresh: 'Refresh',
-    wipMessage: 'Work in progress'
+    buildNamePlaceholder: 'Nome do build',
+    loadingBuilds: 'Carregando builds...',
+    errorLoadingBuilds: 'Erro ao carregar builds',
+    noBuilds: 'Nenhum build encontrado',
+    refresh: 'Atualizar',
+    wipMessage: 'Em desenvolvimento'
   },
   ru: {
     search: 'Поиск',
@@ -185,12 +185,12 @@ export const uiTranslations: Record<string, UILabels> = {
     weapon: 'Оружие',
     descendant: 'Наследник',
     save: 'Сохранить',
-    buildNamePlaceholder: 'Build Name',
-    loadingBuilds: 'Loading builds...',
-    errorLoadingBuilds: 'Error loading builds',
-    noBuilds: 'No builds found',
-    refresh: 'Refresh',
-    wipMessage: 'Work in progress'
+    buildNamePlaceholder: 'Название билда',
+    loadingBuilds: 'Загрузка билдов...',
+    errorLoadingBuilds: 'Ошибка загрузки билдов',
+    noBuilds: 'Билды не найдены',
+    refresh: 'Обновить',
+    wipMessage: 'В разработке'
   },
   es: {
     search: 'Buscar',
@@ -201,12 +201,12 @@ export const uiTranslations: Record<string, UILabels> = {
     weapon: 'Arma',
     descendant: 'Descendiente',
     save: 'Guardar',
-    buildNamePlaceholder: 'Build Name',
-    loadingBuilds: 'Loading builds...',
-    errorLoadingBuilds: 'Error loading builds',
-    noBuilds: 'No builds found',
-    refresh: 'Refresh',
-    wipMessage: 'Work in progress'
+    buildNamePlaceholder: 'Nombre de la build',
+    loadingBuilds: 'Cargando builds...',
+    errorLoadingBuilds: 'Error al cargar las builds',
+    noBuilds: 'No se encontraron builds',
+    refresh: 'Actualizar',
+    wipMessage: 'Trabajo en progreso'
   }
 };
 

--- a/TFD-front/src/app/search/search.component.html
+++ b/TFD-front/src/app/search/search.component.html
@@ -1,3 +1,3 @@
 <div class="spacing">
-  ⚠️ Work in progress ⚠️
+  ⚠️ {{ label('wipMessage') }} ⚠️
 </div>

--- a/TFD-front/src/app/search/search.component.html
+++ b/TFD-front/src/app/search/search.component.html
@@ -1,0 +1,3 @@
+<div class="spacing">
+  ⚠️ Work in progress ⚠️
+</div>

--- a/TFD-front/src/app/search/search.component.scss
+++ b/TFD-front/src/app/search/search.component.scss
@@ -1,0 +1,1 @@
+/* placeholder styles for search tab */

--- a/TFD-front/src/app/search/search.component.ts
+++ b/TFD-front/src/app/search/search.component.ts
@@ -1,5 +1,7 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { visualStore } from '../store/display.store';
+import { getUILabel } from '../lang.utils';
 
 @Component({
   standalone: true,
@@ -8,4 +10,10 @@ import { CommonModule } from '@angular/common';
   templateUrl: './search.component.html',
   styleUrls: ['./search.component.scss', '../../styles.scss']
 })
-export class SearchComponent {}
+export class SearchComponent {
+  private visualStore = inject(visualStore);
+
+  label(key: Parameters<typeof getUILabel>[1]) {
+    return getUILabel(this.visualStore.get_lang(), key);
+  }
+}

--- a/TFD-front/src/app/search/search.component.ts
+++ b/TFD-front/src/app/search/search.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  standalone: true,
+  selector: 'search-tab',
+  imports: [CommonModule],
+  templateUrl: './search.component.html',
+  styleUrls: ['./search.component.scss', '../../styles.scss']
+})
+export class SearchComponent {}

--- a/TFD-front/src/app/store/data.store.ts
+++ b/TFD-front/src/app/store/data.store.ts
@@ -250,6 +250,27 @@ export const dataStore = signalStore(
       patchState(store, { unlock: { ...store.unlock(), reactors: true } });
       store.reactorResource?.reload();
     },
+    load_all: () => {
+      patchState(store, {
+        unlock: {
+          ...store.unlock(),
+          modules: true,
+          translations: true,
+          descendants: true,
+          weapons: true,
+          cores: store.unlock().cores,
+          externals: true,
+          reactors: true,
+          boards: store.unlock().boards
+        }
+      });
+      store.modulesResource?.reload();
+      store.translationResource?.reload();
+      store.descendantResource?.reload();
+      store.weaponResource?.reload();
+      store.externalResource?.reload();
+      store.reactorResource?.reload();
+    },
     refresh_modules: () => store.modulesResource?.reload(),
     refresh_translation: () => store.translationResource?.reload(),
     refresh_descendants: () => store.descendantResource?.reload(),

--- a/TFD-front/src/main.ts
+++ b/TFD-front/src/main.ts
@@ -4,6 +4,8 @@ import { provideHttpClient } from '@angular/common/http';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { enableProdMode, provideExperimentalZonelessChangeDetection } from '@angular/core';
 import { importProvidersFrom } from '@angular/core';
+import { provideRouter } from '@angular/router';
+import { routes } from './app/app.routes';
 import { SocialLoginModule, SocialAuthServiceConfig } from '@abacritt/angularx-social-login';
 import { FormsModule } from '@angular/forms';
 import { GoogleLoginProvider } from '@abacritt/angularx-social-login';
@@ -15,6 +17,7 @@ enableProdMode();
 bootstrapApplication(AppComponent, {
   providers: [
     provideExperimentalZonelessChangeDetection(),
+    provideRouter(routes),
     provideHttpClient(),
     provideAnimations(),
     importProvidersFrom(SocialLoginModule),


### PR DESCRIPTION
## Summary
- sync descendant filter when build data changes
- adjust weapon and descendant counts when loading builds
- switch to build maker tab after loading a saved build
- load builds directly from the URL using router

## Testing
- `npm test --silent` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_6849e03c13d0832095e072b1a888acf7