### PR TITLE
FT: add build deletion

### DIFF
--- a/TFD-front/AGENT.MD
+++ b/TFD-front/AGENT.MD
@@ -60,3 +60,6 @@ TFD-front/
 ## PR/Commit Guidelines
 - All commit / PR messages / branch name in English
 - Link changes to related feature/bug in message
+
+## display
+- every displayed messages / letters should be fully translated and use uiTranslations feature

--- a/TFD-front/src/app/build/descendant/descendant.component.ts
+++ b/TFD-front/src/app/build/descendant/descendant.component.ts
@@ -88,7 +88,6 @@ export class DescedantBuildComponent {
       const res = this.data_store.descendantResource.value()
         ?.filter(des => des.descendant_id === id)[0]
         ?? unsetDescendants
-      console.log(res);
       this.build_store.setDescendant(res);
       this.module_data.descendant = res.descendant_id
 

--- a/TFD-front/src/app/build/main/main.component.ts
+++ b/TFD-front/src/app/build/main/main.component.ts
@@ -92,7 +92,6 @@ export class MainBuildComponent implements OnInit {
     computed(() => {
       const resource = this.build_store.SaveBuildResource;
       if (resource?.hasValue()) {
-        console.log("oui");
         this.build_store.setBuildID(resource.value().build_id)
       }
     })

--- a/TFD-front/src/app/build/saved/build-card/build-card.component.html
+++ b/TFD-front/src/app/build/saved/build-card/build-card.component.html
@@ -16,7 +16,7 @@
   }
   <div class="but">
     <h3 class="material-icons-outlined" >
-      <div>delete</div>
+      <div (click)="confirmDelete()">delete</div>
     </h3>
   </div>
 

--- a/TFD-front/src/app/build/saved/build-card/build-card.component.ts
+++ b/TFD-front/src/app/build/saved/build-card/build-card.component.ts
@@ -1,5 +1,8 @@
 import { Component, Input, Output, EventEmitter, inject, computed, Signal, signal } from '@angular/core';
 import { buildStore } from '../../../store/build.store';
+import { buildListStore } from '../../../store/build-list.store';
+import { visualStore } from '../../../store/display.store';
+import { getUILabel } from '../../../lang.utils';
 import { CommonModule, DatePipe } from '@angular/common';
 import { MatIconModule } from '@angular/material/icon';
 import { Clipboard } from '@angular/cdk/clipboard';
@@ -22,6 +25,8 @@ export interface BuildSummary { // Exporting for potential use in parent
 })
 export class BuildCardComponent {
   private buildStore = inject(buildStore)
+  private listStore = inject(buildListStore)
+  private visualStore = inject(visualStore)
   @Input({ required: true }) build!: BuildSummary;
   @Output() viewBuild = new EventEmitter<number>();
 
@@ -41,5 +46,13 @@ export class BuildCardComponent {
   unlinkgBuild() {
     this.buildStore.setBuildID(0);
     this.viewBuild.emit(0);
+  }
+
+  confirmDelete() {
+    const message = getUILabel(this.visualStore.get_lang(), 'confirmDelete');
+    if (confirm(message)) {
+      this.listStore.deleteBuild(this.build.build_id);
+      this.listStore.refresh();
+    }
   }
 }

--- a/TFD-front/src/app/lang.utils.ts
+++ b/TFD-front/src/app/lang.utils.ts
@@ -13,6 +13,7 @@ export interface UILabels {
   noBuilds: string;
   refresh: string;
   wipMessage: string;
+  confirmDelete: string;
 }
 
 export const uiTranslations: Record<string, UILabels> = {
@@ -30,7 +31,8 @@ export const uiTranslations: Record<string, UILabels> = {
     errorLoadingBuilds: 'Error loading builds',
     noBuilds: 'No builds found',
     refresh: 'Refresh',
-    wipMessage: 'Work in progress'
+    wipMessage: 'Work in progress',
+    confirmDelete: 'Are you sure you want to delete this build?'
   },
   fr: {
     search: 'Recherche',
@@ -46,7 +48,8 @@ export const uiTranslations: Record<string, UILabels> = {
     errorLoadingBuilds: "Erreur lors du chargement des builds",
     noBuilds: 'Aucun build disponible',
     refresh: 'Rafraîchir',
-    wipMessage: 'Travail en cours'
+    wipMessage: 'Travail en cours',
+    confirmDelete: 'Êtes-vous sûr de vouloir supprimer ce build ?'
   },
   ko: {
     search: '검색',
@@ -62,7 +65,8 @@ export const uiTranslations: Record<string, UILabels> = {
     errorLoadingBuilds: '빌드를 불러오는 데 오류 발생',
     noBuilds: '저장된 빌드가 없습니다',
     refresh: '새로고침',
-    wipMessage: '작업 진행 중'
+    wipMessage: '작업 진행 중',
+    confirmDelete: '이 빌드를 삭제하시겠습니까?'
   },
   de: {
     search: 'Suche',
@@ -78,7 +82,8 @@ export const uiTranslations: Record<string, UILabels> = {
     errorLoadingBuilds: 'Fehler beim Laden der Builds',
     noBuilds: 'Keine Builds gefunden',
     refresh: 'Aktualisieren',
-    wipMessage: 'In Arbeit'
+    wipMessage: 'In Arbeit',
+    confirmDelete: 'Möchten Sie diesen Build wirklich löschen?'
   },
   ja: {
     search: '検索',
@@ -94,7 +99,8 @@ export const uiTranslations: Record<string, UILabels> = {
     errorLoadingBuilds: 'ビルドの読み込みエラー',
     noBuilds: 'ビルドが見つかりません',
     refresh: '更新',
-    wipMessage: '作業中'
+    wipMessage: '作業中',
+    confirmDelete: 'このビルドを削除してよろしいですか？'
   },
   'zh-CN': {
     search: '搜索',
@@ -110,7 +116,8 @@ export const uiTranslations: Record<string, UILabels> = {
     errorLoadingBuilds: '加载构建时出错',
     noBuilds: '没有找到构建',
     refresh: '刷新',
-    wipMessage: '开发中'
+    wipMessage: '开发中',
+    confirmDelete: '确定要删除此构建吗？'
   },
   'zh-TW': {
     search: '搜尋',
@@ -126,7 +133,8 @@ export const uiTranslations: Record<string, UILabels> = {
     errorLoadingBuilds: '載入構建時出錯',
     noBuilds: '沒有找到構建',
     refresh: '重新整理',
-    wipMessage: '開發中'
+    wipMessage: '開發中',
+    confirmDelete: '確定要刪除此構建嗎？'
   },
   it: {
     search: 'Cerca',
@@ -142,7 +150,8 @@ export const uiTranslations: Record<string, UILabels> = {
     errorLoadingBuilds: 'Errore nel caricamento delle build',
     noBuilds: 'Nessuna build trovata',
     refresh: 'Aggiorna',
-    wipMessage: 'Lavori in corso'
+    wipMessage: 'Lavori in corso',
+    confirmDelete: 'Sei sicuro di voler eliminare questa build?'
   },
   pl: {
     search: 'Szukaj',
@@ -158,7 +167,8 @@ export const uiTranslations: Record<string, UILabels> = {
     errorLoadingBuilds: 'Błąd ładowania buildów',
     noBuilds: 'Brak zapisanych buildów',
     refresh: 'Odśwież',
-    wipMessage: 'Prace w toku'
+    wipMessage: 'Prace w toku',
+    confirmDelete: 'Czy na pewno chcesz usunąć ten build?'
   },
   pt: {
     search: 'Buscar',
@@ -174,7 +184,8 @@ export const uiTranslations: Record<string, UILabels> = {
     errorLoadingBuilds: 'Erro ao carregar builds',
     noBuilds: 'Nenhum build encontrado',
     refresh: 'Atualizar',
-    wipMessage: 'Em desenvolvimento'
+    wipMessage: 'Em desenvolvimento',
+    confirmDelete: 'Tem certeza de que deseja excluir este build?'
   },
   ru: {
     search: 'Поиск',
@@ -190,7 +201,8 @@ export const uiTranslations: Record<string, UILabels> = {
     errorLoadingBuilds: 'Ошибка загрузки билдов',
     noBuilds: 'Билды не найдены',
     refresh: 'Обновить',
-    wipMessage: 'В разработке'
+    wipMessage: 'В разработке',
+    confirmDelete: 'Вы уверены, что хотите удалить этот билд?'
   },
   es: {
     search: 'Buscar',
@@ -206,7 +218,8 @@ export const uiTranslations: Record<string, UILabels> = {
     errorLoadingBuilds: 'Error al cargar las builds',
     noBuilds: 'No se encontraron builds',
     refresh: 'Actualizar',
-    wipMessage: 'Trabajo en progreso'
+    wipMessage: 'Trabajo en progreso',
+    confirmDelete: '¿Estás seguro de que deseas eliminar esta build?'
   }
 };
 

--- a/TFD-front/src/app/store/build-list.store.ts
+++ b/TFD-front/src/app/store/build-list.store.ts
@@ -33,8 +33,8 @@ export const buildListStore = signalStore(
           }
         : undefined,
     ),
-    deleteResource: httpResource<unknown>(() =>
-      store._delete() && store.delete_id() > 0
+    deleteResource: httpResource<{success: boolean}>(() =>
+      store._delete()
         ? {
             url: `${environment.apiBaseUrl}/build/${store.delete_id()}`,
             method: 'DELETE',
@@ -51,10 +51,12 @@ export const buildListStore = signalStore(
     deleteBuild: (id: number) => {
       patchState(store, { delete_id: id, _delete: true });
       store.deleteResource.reload();
-      patchState(store, { _delete: false });
+      //TODO: find a way to clean state after resources loaded
+      //patchState(store, { delete_id: 0, _delete: false });
     },
     refresh: () => {
       store.resource.reload();
     },
-  }))
+  })),
+  
 );

--- a/api/api.py
+++ b/api/api.py
@@ -190,5 +190,16 @@ def api_get_build(build_id):
         'build_data': build_data,
     })
 
+
+@app.route('/api/build/<int:build_id>', methods=['DELETE'])
+def api_delete_build(build_id):
+    try:
+        deleted = builds.delete_build(build_id)
+        if not deleted:
+            return jsonify({'success': False, 'error': 'not found'}), 404
+        return jsonify({'success': True}), 200
+    except Exception as e:
+        return jsonify({'success': False, 'error': str(e)}), 500
+
 if __name__ == '__main__':
     app.run(debug=True, host='0.0.0.0', port=4201)

--- a/api/api.py
+++ b/api/api.py
@@ -12,7 +12,7 @@ app = Flask(__name__)
 
 CORS(app)
 CORS(app, resource={r"/api/*": {"origins": "http://localhost:4200"}}, supports_credentials=True)
-CORS(app, supports_credentials=True, methods=["GET", "POST"], allow_headers=["Content-Type"])
+CORS(app, supports_credentials=True, methods=["GET", "POST", "DELETE"], allow_headers=["Content-Type"])
 
 @app.route('/api/user_settings', methods=['POST'])
 def get_user_settings():

--- a/api/sql/AGENT.MD
+++ b/api/sql/AGENT.MD
@@ -30,6 +30,9 @@ sql/
 3. Apply migration (`alembic upgrade head`)
 4. PR should mention any DB schema change
 
+## alembic revisions
+- don't create migration yourself it break things you don't have alembic.ini
+
 ## Data Import
 - Data fetched from remote JSON APIs is normalized before DB insert
 - All importers should handle upserts to avoid duplicates

--- a/api/sql/CRUD/builds.py
+++ b/api/sql/CRUD/builds.py
@@ -67,3 +67,20 @@ def update_build(build_id: int, user_id: str, name: str, data: dict) -> bool:
         return False
     finally:
         session.close()
+
+
+def delete_build(build_id: int) -> bool:
+    session: Session = SessionLocal()
+    try:
+        result = session.execute(
+            text("CALL DeleteUserBuild(:build_id)"),
+            {"build_id": build_id}
+        )
+        session.commit()
+        return result.rowcount > 0
+    except Exception as e:
+        print(f"❌ delete_build (SP): {e}")
+        session.rollback()
+        return False
+    finally:
+        session.close()

--- a/api/sql/alembic/versions/bd774a63875b_setup_builds.py
+++ b/api/sql/alembic/versions/bd774a63875b_setup_builds.py
@@ -81,9 +81,22 @@ def upgrade() -> None:
     END;
     """)
 
+    # Procédure de suppression
+    op.execute("DROP PROCEDURE IF EXISTS DeleteUserBuild;")
+    op.execute("""
+    CREATE PROCEDURE DeleteUserBuild(
+        IN p_build_id INT
+    )
+    BEGIN
+        DELETE FROM user_builds WHERE build_id = p_build_id;
+        SELECT ROW_COUNT() AS affected;
+    END;
+    """)
+
 
 def downgrade() -> None:
     op.execute("DROP PROCEDURE IF EXISTS AddUserBuild;")
     op.execute("DROP PROCEDURE IF EXISTS UpdateUserBuild;")
     op.execute("DROP PROCEDURE IF EXISTS GetUserBuilds;")
     op.execute("DROP PROCEDURE IF EXISTS GetUserBuild;")
+    op.execute("DROP PROCEDURE IF EXISTS DeleteUserBuild;")


### PR DESCRIPTION
## Summary
- extend stored procedure script to support build removal
- add delete_build API
- expose route to remove a build
- allow deleting builds from the list with confirmation
- translate delete prompt for every language

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68541615bff88320a942a634ac97a003