### PR TITLE
Add archeron skill tree UI

### DIFF
--- a/TFD-front/src/app/build/descendant/descendant.component.html
+++ b/TFD-front/src/app/build/descendant/descendant.component.html
@@ -1,8 +1,8 @@
 <div class="descendant">
   <div class="spacing">
     <descendant [descendant]="descendant()" (click)="openDialog()"></descendant>
+    <button type="button" (click)="openSkillTreeDialog()">Skill Tree</button>
   </div>
-  <!-- add skill tree -->
 
   <div class="external">
     <div class="column">

--- a/TFD-front/src/app/build/descendant/descendant.component.scss
+++ b/TFD-front/src/app/build/descendant/descendant.component.scss
@@ -2,7 +2,6 @@
   margin: 50px;
 }
 
-
 .descendant {
   display: flex;
   align-items: center;

--- a/TFD-front/src/app/build/descendant/descendant.component.ts
+++ b/TFD-front/src/app/build/descendant/descendant.component.ts
@@ -77,9 +77,9 @@ export class DescedantBuildComponent {
   openSkillTreeDialog(): void {
     this.data_store.load_boards();
     this.dialog.open(ArcheronTreeComponent, {
-      autoFocus: false,
+      autoFocus: true,
       data: this.build_store.descendant(),
-      width: '550px',
+      width: '600px',
     });
   }
 

--- a/TFD-front/src/app/build/descendant/descendant.component.ts
+++ b/TFD-front/src/app/build/descendant/descendant.component.ts
@@ -10,6 +10,7 @@ import { ModuleResponse } from '../../types/module.types';
 import { defaultDescendants, DescendantsResponse, unsetDescendants } from '../../types/descendant.types';
 import { selectorComponent } from '../selector/selector.component';
 import { MatDialog } from '@angular/material/dialog';
+import { ArcheronTreeComponent } from './tree/archeron-tree.component';
 import { buildStore } from '../../store/build.store';
 
 @Component({
@@ -72,6 +73,14 @@ export class DescedantBuildComponent {
   }
 
   constructor(private dialog: MatDialog) {}
+
+  openSkillTreeDialog(): void {
+    this.data_store.load_boards();
+    this.dialog.open(ArcheronTreeComponent, {
+      autoFocus: false,
+      data: this.build_store.descendant()
+    });
+  }
 
   openDialog(): void {
 

--- a/TFD-front/src/app/build/descendant/descendant.component.ts
+++ b/TFD-front/src/app/build/descendant/descendant.component.ts
@@ -78,7 +78,8 @@ export class DescedantBuildComponent {
     this.data_store.load_boards();
     this.dialog.open(ArcheronTreeComponent, {
       autoFocus: false,
-      data: this.build_store.descendant()
+      data: this.build_store.descendant(),
+      width: '550px',
     });
   }
 
@@ -97,7 +98,6 @@ export class DescedantBuildComponent {
       const res = this.data_store.descendantResource.value()
         ?.filter(des => des.descendant_id === id)[0]
         ?? unsetDescendants
-      console.log(res);
       this.build_store.setDescendant(res);
       this.module_data.descendant = res.descendant_id
 

--- a/TFD-front/src/app/build/descendant/tree/archeron-tree.component.html
+++ b/TFD-front/src/app/build/descendant/tree/archeron-tree.component.html
@@ -1,17 +1,23 @@
-<div class="tree" *ngIf="board">
-  <div class="board" [style.gridTemplateColumns]="'repeat(' + board.column_size + ', 50px)'" [style.gridTemplateRows]="'repeat(' + board.row_size + ', 50px)'">
-    @for (n of board.nodes; track n.node_id) {
-      <div class="cell gradient-square" [ngClass]="n.tier_id ?? ''" [class.active]="active().has(n.node_id)" [style.gridColumn]="n.position_column" [style.gridRow]="n.position_row" (click)="toggle(n)" (mouseenter)="updateInfo(n)">
-        <img [src]="n.image_url ?? ''" />
-      </div>
-    }
-  </div>
+<div class="tree">
+  @if (board) {
+    <div class="board"
+         [style.gridTemplateColumns]="'repeat(' + board.column_size + ', var(--scale))'"
+         [style.gridTemplateRows]="'repeat(' + board.row_size + ', var(--scale))'">
+      @for (n of board.nodes; track n.node_id) {
+        <div class="cell gradient-square" [ngClass]="n.tier_id ?? ''" [class.active]="active().has(n.node_id)" [style.gridColumn]="n.position_column" [style.gridRow]="n.position_row" (click)="toggle(n)" (mouseenter)="updateInfo(n)">
+          <img [src]="n.image_url ?? ''" />
+        </div>
+      }
+    </div>
+  }
   <div class="info">
     <h3>{{ hoverName() }}</h3>
+    <!--
     <ul>
       @for (e of hoverEffects(); track e.stat_id) {
         <li>{{ e.stat_id }} {{ e.operator_type }} {{ e.stat_value }}</li>
       }
     </ul>
+    -->
   </div>
 </div>

--- a/TFD-front/src/app/build/descendant/tree/archeron-tree.component.html
+++ b/TFD-front/src/app/build/descendant/tree/archeron-tree.component.html
@@ -1,0 +1,17 @@
+<div class="tree" *ngIf="board">
+  <div class="board" [style.gridTemplateColumns]="'repeat(' + board.column_size + ', 50px)'" [style.gridTemplateRows]="'repeat(' + board.row_size + ', 50px)'">
+    @for (n of board.nodes; track n.node_id) {
+      <div class="cell gradient-square" [ngClass]="n.tier_id ?? ''" [class.active]="active().has(n.node_id)" [style.gridColumn]="n.position_column" [style.gridRow]="n.position_row" (click)="toggle(n)" (mouseenter)="updateInfo(n)">
+        <img [src]="n.image_url ?? ''" />
+      </div>
+    }
+  </div>
+  <div class="info">
+    <h3>{{ hoverName() }}</h3>
+    <ul>
+      @for (e of hoverEffects(); track e.stat_id) {
+        <li>{{ e.stat_id }} {{ e.operator_type }} {{ e.stat_value }}</li>
+      }
+    </ul>
+  </div>
+</div>

--- a/TFD-front/src/app/build/descendant/tree/archeron-tree.component.html
+++ b/TFD-front/src/app/build/descendant/tree/archeron-tree.component.html
@@ -1,5 +1,5 @@
-<div class="tree">
-  @if (board) {
+    @for (n of board.nodes; track track) {
+      <div class="cell gradient-square" [ngClass]="n.tier_id ?? ''" [class.active]="active().has(key(n))" [style.gridColumn]="n.position_column" [style.gridRow]="n.position_row" (click)="toggle(n)" (mouseenter)="updateInfo(n)">
     <div class="board"
          [style.gridTemplateColumns]="'repeat(' + board.column_size + ', var(--scale))'"
          [style.gridTemplateRows]="'repeat(' + board.row_size + ', var(--scale))'">

--- a/TFD-front/src/app/build/descendant/tree/archeron-tree.component.html
+++ b/TFD-front/src/app/build/descendant/tree/archeron-tree.component.html
@@ -1,15 +1,13 @@
-    @for (n of board.nodes; track track) {
+<div class="tree">
+  <div class="board"
+    [style.gridTemplateColumns]="'repeat(' + board?.column_size + ', var(--scale))'"
+    [style.gridTemplateRows]="'repeat(' + board?.row_size + ', var(--scale))'">
+    @for (n of board?.nodes; track n.node_id) {
       <div class="cell gradient-square" [ngClass]="n.tier_id ?? ''" [class.active]="active().has(key(n))" [style.gridColumn]="n.position_column" [style.gridRow]="n.position_row" (click)="toggle(n)" (mouseenter)="updateInfo(n)">
-    <div class="board"
-         [style.gridTemplateColumns]="'repeat(' + board.column_size + ', var(--scale))'"
-         [style.gridTemplateRows]="'repeat(' + board.row_size + ', var(--scale))'">
-      @for (n of board.nodes; track n.node_id) {
-        <div class="cell gradient-square" [ngClass]="n.tier_id ?? ''" [class.active]="active().has(n.node_id)" [style.gridColumn]="n.position_column" [style.gridRow]="n.position_row" (click)="toggle(n)" (mouseenter)="updateInfo(n)">
-          <img [src]="n.image_url ?? ''" />
-        </div>
-      }
-    </div>
-  }
+        <img [src]="n.image_url ?? ''" />
+      </div>
+    }
+  </div>
   <div class="info">
     <h3>{{ hoverName() }}</h3>
     <!--

--- a/TFD-front/src/app/build/descendant/tree/archeron-tree.component.scss
+++ b/TFD-front/src/app/build/descendant/tree/archeron-tree.component.scss
@@ -2,17 +2,22 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  overflow: hidden;
+  background: #333333 !important;
+  color: #fff;
 }
 
 .board {
+  --scale: 28px;
+  padding: 10px;
   display: grid;
-  gap: 4px;
+  gap: 1px;
 }
 
 .cell {
   position: relative;
-  width: 50px;
-  height: 50px;
+  width: var(--scale);
+  height: var(--scale);
   cursor: pointer;
 }
 
@@ -27,41 +32,27 @@
 }
 
 .gradient-square.Tier1 {
-  background: linear-gradient(
-      135deg,
-      rgba(23, 113, 153, 0.5) 0%,
-      rgba(255, 255, 255, 0) 50%,
-      rgba(23, 113, 153, 0.5) 100%
-  );
+  background: rgba(23, 113, 153, 0.2);
 }
 
 .gradient-square.Tier2 {
-  background: linear-gradient(
-      135deg,
-      rgba(125, 23, 153, 0.5) 0%,
-      rgba(255, 255, 255, 0) 50%,
-      rgba(125, 23, 153, 0.5) 100%
-  );
+  background: rgba(125, 23, 153, 0.2);
 }
 
 .gradient-square.Tier3 {
-  background: linear-gradient(
-      135deg,
-      rgba(153, 136, 23, 0.5) 0%,
-      rgba(255, 255, 255, 0) 50%,
-      rgba(153, 136, 23, 0.5) 100%
-  );
+  background: rgba(153, 136, 23, 0.2)
 }
 
 .gradient-square.Tier4 {
-  background: linear-gradient(
-      135deg,
-      rgba(153, 53, 23, 0.5) 0%,
-      rgba(255, 255, 255, 0) 50%,
-      rgba(153, 53, 23, 0.5) 100%
-  );
+  background: rgba(153, 53, 23, 0.2)
 }
 
 .info {
   margin-top: 10px;
+}
+
+@media (max-width: 600px) {
+  .board {
+    --scale: 18px;
+  }
 }

--- a/TFD-front/src/app/build/descendant/tree/archeron-tree.component.scss
+++ b/TFD-front/src/app/build/descendant/tree/archeron-tree.component.scss
@@ -65,10 +65,14 @@
 
 .info {
   margin-top: 10px;
+  font-size: 13px;
 }
 
 @media (max-width: 600px) {
   .board {
     --scale: 18px;
+  }
+  .info {
+    font-size: 8px;
   }
 }

--- a/TFD-front/src/app/build/descendant/tree/archeron-tree.component.scss
+++ b/TFD-front/src/app/build/descendant/tree/archeron-tree.component.scss
@@ -8,7 +8,7 @@
 }
 
 .board {
-  --scale: 28px;
+  --scale: 25px;
   padding: 10px;
   display: grid;
   gap: 1px;
@@ -35,16 +35,32 @@
   background: rgba(23, 113, 153, 0.2);
 }
 
+.gradient-square.Tier1.active {
+  background: rgba(39, 184, 255, 0.7);
+}
+
 .gradient-square.Tier2 {
   background: rgba(125, 23, 153, 0.2);
+}
+
+.gradient-square.Tier2.active {
+  background: rgba(207, 35, 253, 0.7);
 }
 
 .gradient-square.Tier3 {
   background: rgba(153, 136, 23, 0.2)
 }
 
+.gradient-square.Tier3.active {
+  background: rgba(255, 226, 38, 0.7)
+}
+
 .gradient-square.Tier4 {
   background: rgba(153, 53, 23, 0.2)
+}
+
+.gradient-square.Tier4.active {
+  background: rgba(251, 87, 39, 0.7)
 }
 
 .info {

--- a/TFD-front/src/app/build/descendant/tree/archeron-tree.component.scss
+++ b/TFD-front/src/app/build/descendant/tree/archeron-tree.component.scss
@@ -1,0 +1,67 @@
+.tree {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.board {
+  display: grid;
+  gap: 4px;
+}
+
+.cell {
+  position: relative;
+  width: 50px;
+  height: 50px;
+  cursor: pointer;
+}
+
+.cell.active {
+  outline: 2px solid #ffffff;
+}
+
+.cell img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.gradient-square.Tier1 {
+  background: linear-gradient(
+      135deg,
+      rgba(23, 113, 153, 0.5) 0%,
+      rgba(255, 255, 255, 0) 50%,
+      rgba(23, 113, 153, 0.5) 100%
+  );
+}
+
+.gradient-square.Tier2 {
+  background: linear-gradient(
+      135deg,
+      rgba(125, 23, 153, 0.5) 0%,
+      rgba(255, 255, 255, 0) 50%,
+      rgba(125, 23, 153, 0.5) 100%
+  );
+}
+
+.gradient-square.Tier3 {
+  background: linear-gradient(
+      135deg,
+      rgba(153, 136, 23, 0.5) 0%,
+      rgba(255, 255, 255, 0) 50%,
+      rgba(153, 136, 23, 0.5) 100%
+  );
+}
+
+.gradient-square.Tier4 {
+  background: linear-gradient(
+      135deg,
+      rgba(153, 53, 23, 0.5) 0%,
+      rgba(255, 255, 255, 0) 50%,
+      rgba(153, 53, 23, 0.5) 100%
+  );
+}
+
+.info {
+  margin-top: 10px;
+}

--- a/TFD-front/src/app/build/descendant/tree/archeron-tree.component.ts
+++ b/TFD-front/src/app/build/descendant/tree/archeron-tree.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject, inject, effect, signal } from '@angular/core';
+import { Component, Inject, inject, effect, signal, computed } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
 import { dataStore, defaultTranslate, TranslationString, BoardNode, Boards, NodeEffect } from '../../../store/data.store';
@@ -25,10 +25,19 @@ export class ArcheronTreeComponent {
   constructor(@Inject(MAT_DIALOG_DATA) public descendant: DescendantsResponse) {
     this.data_store.load_boards();
     effect(() => {
-      const boards = this.data_store.BoardResource.value() ?? [];
-      this.board = boards.find((b: Boards) => b.board_group_id === descendant.descendant_group_id);
+      this.board = computed(() => this.data_store.BoardResource.value() ?? [])()[1];
+      this.board = this.shiftBoard(this.board)
     });
-  }
+  };
+
+  shiftBoard = (board: Boards): Boards => ({
+    ...board,
+    nodes: board.nodes.map(node => ({
+      ...node,
+      position_row:    node.position_row    + 1,
+      position_column: node.position_column + 1,
+    }))
+  });
 
   toggle(node: BoardNode): void {
     if (!this.canActivate(node)) {

--- a/TFD-front/src/app/build/descendant/tree/archeron-tree.component.ts
+++ b/TFD-front/src/app/build/descendant/tree/archeron-tree.component.ts
@@ -1,0 +1,85 @@
+import { Component, Inject, inject, effect, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
+import { dataStore, defaultTranslate, TranslationString, BoardNode, Boards, NodeEffect } from '../../../store/data.store';
+import { visualStore } from '../../../store/display.store';
+import { getTranslationField } from '../../../lang.utils';
+import { DescendantsResponse } from '../../../types/descendant.types';
+
+@Component({
+  standalone: true,
+  selector: 'archeron-tree',
+  imports: [CommonModule, MatDialogModule],
+  templateUrl: './archeron-tree.component.html',
+  styleUrls: ['./archeron-tree.component.scss']
+})
+export class ArcheronTreeComponent {
+  readonly data_store = inject(dataStore);
+  readonly visual_store = inject(visualStore);
+
+  board?: Boards;
+  active = signal(new Set<number>());
+  hoverName = signal('');
+  hoverEffects = signal<NodeEffect[]>([]);
+
+  constructor(@Inject(MAT_DIALOG_DATA) public descendant: DescendantsResponse) {
+    this.data_store.load_boards();
+    effect(() => {
+      const boards = this.data_store.BoardResource.value() ?? [];
+      this.board = boards.find((b: Boards) => b.board_group_id === descendant.descendant_group_id);
+    });
+  }
+
+  toggle(node: BoardNode): void {
+    if (!this.canActivate(node)) {
+      return;
+    }
+    const set = new Set(this.active());
+    if (set.has(node.node_id)) {
+      set.delete(node.node_id);
+    } else {
+      set.add(node.node_id);
+    }
+    this.active.set(set);
+  }
+
+  private neighbors(node: BoardNode): BoardNode[] {
+    if (!this.board) return [];
+    return this.board.nodes.filter(n =>
+      Math.abs(n.position_row - node.position_row) + Math.abs(n.position_column - node.position_column) === 1
+    );
+  }
+
+  private pathExists(target: BoardNode): boolean {
+    if (!this.board) return false;
+    const starts = this.board.nodes.filter(n => n.node_type?.toLowerCase() === 'start');
+    const visited = new Set<number>();
+    const stack = [...starts];
+    const active = this.active();
+    while (stack.length) {
+      const current = stack.pop()!;
+      if (current.node_id === target.node_id) return true;
+      visited.add(current.node_id);
+      for (const n of this.neighbors(current)) {
+        if ((active.has(n.node_id) || n.node_id === target.node_id) && !visited.has(n.node_id)) {
+          stack.push(n);
+        }
+      }
+    }
+    return false;
+  }
+
+  canActivate(node: BoardNode): boolean {
+    if (!this.board) return false;
+    if (node.node_type?.toLowerCase() === 'start') return true;
+    return this.pathExists(node);
+  }
+
+  updateInfo(node: BoardNode): void {
+    const langKey = getTranslationField(this.visual_store.get_lang());
+    const translations = this.data_store.translationResource.value();
+    const tr: TranslationString = translations ? translations[node.name_id - 1] : defaultTranslate;
+    this.hoverName.set((tr as any)[langKey] ?? '');
+    this.hoverEffects.set(node.effects);
+  }
+}

--- a/TFD-front/src/app/build/descendant/tree/archeron-tree.component.ts
+++ b/TFD-front/src/app/build/descendant/tree/archeron-tree.component.ts
@@ -1,17 +1,36 @@
-import { Component, Inject, inject, effect, signal, computed } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
-import { dataStore, defaultTranslate, TranslationString, BoardNode, Boards, NodeEffect } from '../../../store/data.store';
-import { visualStore } from '../../../store/display.store';
-import { getTranslationField } from '../../../lang.utils';
-import { DescendantsResponse } from '../../../types/descendant.types';
+  active = signal(new Set<string>());
+  key(node: BoardNode): string {
+    return `${node.position_row}-${node.position_column}`;
+  }
 
-@Component({
-  standalone: true,
-  selector: 'archeron-tree',
-  imports: [CommonModule, MatDialogModule],
-  templateUrl: './archeron-tree.component.html',
-  styleUrls: ['./archeron-tree.component.scss']
+  track = (_: number, node: BoardNode) => this.key(node);
+
+    const key = this.key(node);
+    if (set.has(key)) {
+      set.delete(key);
+      if (this.board) {
+        for (const n of this.board.nodes) {
+          const k = this.key(n);
+          if (set.has(k) && n.node_type?.toLowerCase() !== 'start' && !this.pathExistsWithSet(n, set)) {
+            set.delete(k);
+          }
+        }
+      }
+      if (!this.canActivate(node)) return;
+      set.add(key);
+
+    return this.pathExistsWithSet(target, this.active());
+  }
+
+  private pathExistsWithSet(target: BoardNode, active: Set<string>): boolean {
+    const visited = new Set<string>();
+    const targetKey = this.key(target);
+      const currentKey = this.key(current);
+      if (currentKey === targetKey) return true;
+      visited.add(currentKey);
+        const k = this.key(n);
+        if ((active.has(k) || k === targetKey) && !visited.has(k)) {
+    return this.pathExistsWithSet(node, this.active());
 })
 export class ArcheronTreeComponent {
   readonly data_store = inject(dataStore);

--- a/TFD-front/src/app/build/descendant/tree/archeron-tree.component.ts
+++ b/TFD-front/src/app/build/descendant/tree/archeron-tree.component.ts
@@ -1,45 +1,31 @@
-  active = signal(new Set<string>());
-  key(node: BoardNode): string {
-    return `${node.position_row}-${node.position_column}`;
-  }
+import { Component, Inject, inject, effect, signal, computed } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
+import { dataStore, defaultTranslate, TranslationString, BoardNode, Boards, NodeEffect } from '../../../store/data.store';
+import { visualStore } from '../../../store/display.store';
+import { getTranslationField } from '../../../lang.utils';
+import { DescendantsResponse } from '../../../types/descendant.types';
 
-  track = (_: number, node: BoardNode) => this.key(node);
-
-    const key = this.key(node);
-    if (set.has(key)) {
-      set.delete(key);
-      if (this.board) {
-        for (const n of this.board.nodes) {
-          const k = this.key(n);
-          if (set.has(k) && n.node_type?.toLowerCase() !== 'start' && !this.pathExistsWithSet(n, set)) {
-            set.delete(k);
-          }
-        }
-      }
-      if (!this.canActivate(node)) return;
-      set.add(key);
-
-    return this.pathExistsWithSet(target, this.active());
-  }
-
-  private pathExistsWithSet(target: BoardNode, active: Set<string>): boolean {
-    const visited = new Set<string>();
-    const targetKey = this.key(target);
-      const currentKey = this.key(current);
-      if (currentKey === targetKey) return true;
-      visited.add(currentKey);
-        const k = this.key(n);
-        if ((active.has(k) || k === targetKey) && !visited.has(k)) {
-    return this.pathExistsWithSet(node, this.active());
+@Component({
+  standalone: true,
+  selector: 'archeron-tree',
+  imports: [CommonModule, MatDialogModule],
+  templateUrl: './archeron-tree.component.html',
+  styleUrls: ['./archeron-tree.component.scss']
 })
 export class ArcheronTreeComponent {
   readonly data_store = inject(dataStore);
   readonly visual_store = inject(visualStore);
 
   board?: Boards;
-  active = signal(new Set<number>());
   hoverName = signal('');
   hoverEffects = signal<NodeEffect[]>([]);
+  active = signal(new Set<string>());
+  readonly MAX_ACTIVE = 40;   // Limite maximale de cases actives en même temps
+
+  key(node: BoardNode): string {
+    return `${node.position_row}-${node.position_column}`;
+  }
 
   constructor(@Inject(MAT_DIALOG_DATA) public descendant: DescendantsResponse) {
     this.data_store.load_boards();
@@ -53,22 +39,38 @@ export class ArcheronTreeComponent {
     ...board,
     nodes: board.nodes.map(node => ({
       ...node,
-      position_row:    node.position_row    + 1,
+      position_row: node.position_row + 1,
       position_column: node.position_column + 1,
     }))
   });
 
   toggle(node: BoardNode): void {
-    if (!this.canActivate(node)) {
-      return;
-    }
+    if (!this.board) return;
+
     const set = new Set(this.active());
-    if (set.has(node.node_id)) {
-      set.delete(node.node_id);
+    const key = this.key(node);
+    const isActive = set.has(key);
+
+    if (isActive) {
+      set.delete(key);
+
+      for (const n of this.board.nodes) {
+        const k = this.key(n);
+        if (
+          set.has(k) &&
+          n.node_type?.toLowerCase() !== 'start' &&
+          !this.pathExistsWithSet(n, set)
+        ) {
+          return;
+        }
+      }
+
+      this.active.set(set);
     } else {
-      set.add(node.node_id);
+      if (!this.canActivate(node)) return;
+      set.add(key);
+      this.active.set(set);
     }
-    this.active.set(set);
   }
 
   private neighbors(node: BoardNode): BoardNode[] {
@@ -78,29 +80,45 @@ export class ArcheronTreeComponent {
     );
   }
 
-  private pathExists(target: BoardNode): boolean {
-    if (!this.board) return false;
-    const starts = this.board.nodes.filter(n => n.node_type?.toLowerCase() === 'start');
-    const visited = new Set<number>();
-    const stack = [...starts];
-    const active = this.active();
-    while (stack.length) {
-      const current = stack.pop()!;
-      if (current.node_id === target.node_id) return true;
-      visited.add(current.node_id);
-      for (const n of this.neighbors(current)) {
-        if ((active.has(n.node_id) || n.node_id === target.node_id) && !visited.has(n.node_id)) {
-          stack.push(n);
-        }
-      }
-    }
-    return false;
-  }
-
   canActivate(node: BoardNode): boolean {
     if (!this.board) return false;
     if (node.node_type?.toLowerCase() === 'start') return true;
-    return this.pathExists(node);
+
+    if (this.active().size >= this.MAX_ACTIVE) return false;
+
+    return this.neighbors(node).some(
+      n =>
+        n.node_type?.toLowerCase() === 'start' ||
+        this.active().has(this.key(n))
+    );
+  }
+
+  private pathExistsWithSet(target: BoardNode, active: Set<string>): boolean {
+    if (!this.board) return false;
+
+    const start = this.board.nodes.find(
+      n => n.node_type?.toLowerCase() === 'start'
+    );
+    if (!start) return false;
+
+    const visited = new Set<string>();
+    const stack: BoardNode[] = [start];
+
+    while (stack.length) {
+      const current = stack.pop()!;
+      const currentKey = this.key(current);
+      if (currentKey === this.key(target)) return true;
+      visited.add(currentKey);
+
+      for (const neigh of this.neighbors(current)) {
+        const k = this.key(neigh);
+        if (!visited.has(k) && (k === this.key(target) || active.has(k))) {
+          stack.push(neigh);
+        }
+      }
+    }
+
+    return false;
   }
 
   updateInfo(node: BoardNode): void {

--- a/TFD-front/src/app/store/build-list.store.ts
+++ b/TFD-front/src/app/store/build-list.store.ts
@@ -36,4 +36,5 @@ export const buildListStore = signalStore(
       store.resource.reload();
     },
   }))
+
 );

--- a/TFD-front/src/app/store/data.store.ts
+++ b/TFD-front/src/app/store/data.store.ts
@@ -119,6 +119,8 @@ export interface BoardNode {
   node_type:             string | null;
   tier_id:               string | null;
   required_tuning_point: number | null;
+  position_row:          number;
+  position_column:       number;
   effects:               NodeEffect[];
 }
 
@@ -127,6 +129,8 @@ export interface Boards {
   board_id:        number;
   board_name_id:   number;
   board_group_id:  number;
+  row_size:        number;
+  column_size:     number;
   board_image_url: string | null;
   nodes:           BoardNode[];
 }
@@ -216,7 +220,7 @@ export const dataStore = signalStore(
       withCredentials: true,
       transferCache: true,
     }) : undefined),
-    BoardResource: httpResource<Boards | undefined>(() => store.unlock.boards() ? ({
+    BoardResource: httpResource<Boards[] | undefined>(() => store.unlock.boards() ? ({
       url: `${API_URL}/boards`,
       method: 'GET',
       withCredentials: true,
@@ -250,6 +254,10 @@ export const dataStore = signalStore(
       patchState(store, { unlock: { ...store.unlock(), reactors: true } });
       store.reactorResource?.reload();
     },
+    load_boards: () => {
+      patchState(store, { unlock: { ...store.unlock(), boards: true } });
+      store.BoardResource?.reload();
+    },
     load_all: () => {
       patchState(store, {
         unlock: {
@@ -270,11 +278,15 @@ export const dataStore = signalStore(
       store.weaponResource?.reload();
       store.externalResource?.reload();
       store.reactorResource?.reload();
+      if (store.unlock().boards) {
+        store.BoardResource?.reload();
+      }
     },
     refresh_modules: () => store.modulesResource?.reload(),
     refresh_translation: () => store.translationResource?.reload(),
     refresh_descendants: () => store.descendantResource?.reload(),
     refresh_externals: () => store.externalResource?.reload(),
     refresh_reactors: () => store.reactorResource?.reload(),
+    refresh_boards: () => store.BoardResource?.reload(),
   }))
 );

--- a/TFD-front/src/app/store/data.store.ts
+++ b/TFD-front/src/app/store/data.store.ts
@@ -125,14 +125,14 @@ export interface BoardNode {
 }
 
 export interface Boards {
-  id:              number;
-  board_id:        number;
-  board_name_id:   number;
-  board_group_id:  number;
-  row_size:        number;
-  column_size:     number;
+  id: number;
+  board_id: number;
+  board_name_id: number;
+  arche_tuning_board_id: number;
+  row_size: number;
+  column_size: number;
   board_image_url: string | null;
-  nodes:           BoardNode[];
+  nodes: BoardNode[];
 }
 
 export type unlock = {


### PR DESCRIPTION
## Summary
- define board and node info in data store
- implement archeron tree component with activation rules
- add skill tree button beside descendant image
- support loading boards via data store

## Testing
- `npm run build` *(fails: Inlining of fonts failed due to 403)*

------
https://chatgpt.com/codex/tasks/task_e_6857eee7937083209eaaf20a9c2af865