### PR TITLE
Improve reactor selection popup

### DIFF
--- a/TFD-front/src/app/build/selector/selector.component.html
+++ b/TFD-front/src/app/build/selector/selector.component.html
@@ -1,5 +1,5 @@
 <div class="contain">
-  <input class="input" type="text" placeholder="Search ..." [(ngModel)]="searchText" />
+  <input class="input" type="text" [placeholder]="label('search')" [(ngModel)]="searchText" />
 
   <div class="modules-container">
     @if(type === "modules") {
@@ -19,8 +19,22 @@
         <weapon [weapon]="m" (click)="selectWeapon(m)"></weapon>
       }
     } @else if (type === "reactors") {
-      @for (m of filteredReactors(); track m.id) {
-        <reactor [reactor]="m" (click)="selectReactor(m)"></reactor>
+      @if (!selectedReactorGroup) {
+        @for (g of reactorGroups(); track g[0].id) {
+          <reactor [reactor]="g[0]" (click)="chooseReactorGroup(g)"></reactor>
+        }
+      } @else {
+        <button class="back" (click)="backToReactorImages()">{{ label('back') }}</button>
+        @for (r of selectedReactorGroup; track r.id) {
+          <div class="reactor-option" (click)="selectSubReactor(r)">
+            <reactor [reactor]="r"></reactor>
+            <div class="stats">
+              @for (s of r.base_stat; track s.stat_id) {
+                <span>{{ s.stat_id }}: {{ s.stat_value }}</span>
+              }
+            </div>
+          </div>
+        }
       }
     } @else if (type === "externals") {
       @for (m of filteredExternals(); track m.id) {

--- a/TFD-front/src/app/build/selector/selector.component.scss
+++ b/TFD-front/src/app/build/selector/selector.component.scss
@@ -25,3 +25,21 @@
   flex-wrap: wrap;
   gap: 9px;
 }
+
+.back {
+  margin: 5px;
+}
+
+.reactor-option {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  cursor: pointer;
+}
+
+.stats {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  font-size: 12px;
+}

--- a/TFD-front/src/app/build/selector/selector.component.ts
+++ b/TFD-front/src/app/build/selector/selector.component.ts
@@ -2,7 +2,7 @@ import {Component, Inject, inject, Input} from '@angular/core';
 
 import {dataStore, defaultTranslate, TranslationString} from '../../store/data.store';
 import { visualStore } from '../../store/display.store';
-import { getTranslationField } from '../../lang.utils';
+import { getTranslationField, getUILabel } from '../../lang.utils';
 import { ModuleComponent } from '../module/display/module-display.component';
 import { ReactorDisplayComponent } from '../reactor/display/reactor-display.component';
 import { ExternalDisplayComponent } from '../external/display/external-display.component';
@@ -43,6 +43,7 @@ export class selectorComponent {
 
   searchText = '';
   requireDescendant = false;
+  selectedReactorGroup: Reactor[] | null = null;
 
   compareDescendantIDs(module: ModuleResponse): boolean {
     const ids = (module.available_descendant_id ?? '')
@@ -85,6 +86,19 @@ export class selectorComponent {
     return this.data_store.reactorResource.value()
   }
 
+  reactorGroups() {
+    const list = this.data_store.reactorResource.value() ?? [];
+    const groups: Record<string, Reactor[]> = {};
+    for (const r of list) {
+      const key = r.image_url ?? '';
+      if (!groups[key]) {
+        groups[key] = [];
+      }
+      groups[key].push(r);
+    }
+    return Object.values(groups);
+  }
+
   filteredExternals() {
     return this.data_store.externalResource.value()
   }
@@ -105,6 +119,10 @@ export class selectorComponent {
     // resources are preloaded in main component
   }
 
+  label(key: Parameters<typeof getUILabel>[1]) {
+    return getUILabel(this.visual_store.get_lang(), key);
+  }
+
   selectModules(module: ModuleResponse): void {
     this.dialogRef.close(module.module_id);
   }
@@ -119,6 +137,22 @@ export class selectorComponent {
 
   selectReactor(reactor: Reactor): void {
     this.dialogRef.close(reactor.reactor_id);
+  }
+
+  chooseReactorGroup(group: Reactor[]): void {
+    if (group.length === 1) {
+      this.selectReactor(group[0]);
+    } else {
+      this.selectedReactorGroup = group;
+    }
+  }
+
+  selectSubReactor(reactor: Reactor): void {
+    this.selectReactor(reactor);
+  }
+
+  backToReactorImages(): void {
+    this.selectedReactorGroup = null;
   }
 
   selectExternal(external: ExternalComponent): void {

--- a/TFD-front/src/app/lang.utils.ts
+++ b/TFD-front/src/app/lang.utils.ts
@@ -14,6 +14,8 @@ export interface UILabels {
   refresh: string;
   wipMessage: string;
   confirmDelete: string;
+  selectSubStats: string;
+  back: string;
 }
 
 export const uiTranslations: Record<string, UILabels> = {
@@ -32,7 +34,9 @@ export const uiTranslations: Record<string, UILabels> = {
     noBuilds: 'No builds found',
     refresh: 'Refresh',
     wipMessage: 'Work in progress',
-    confirmDelete: 'Are you sure you want to delete this build?'
+    confirmDelete: 'Are you sure you want to delete this build?',
+    selectSubStats: 'Select Sub Stat',
+    back: 'Back'
   },
   fr: {
     search: 'Recherche',
@@ -49,7 +53,9 @@ export const uiTranslations: Record<string, UILabels> = {
     noBuilds: 'Aucun build disponible',
     refresh: 'Rafraîchir',
     wipMessage: 'Travail en cours',
-    confirmDelete: 'Êtes-vous sûr de vouloir supprimer ce build ?'
+    confirmDelete: 'Êtes-vous sûr de vouloir supprimer ce build ?',
+    selectSubStats: 'Choisir Sous-Stat',
+    back: 'Retour'
   },
   ko: {
     search: '검색',
@@ -66,7 +72,9 @@ export const uiTranslations: Record<string, UILabels> = {
     noBuilds: '저장된 빌드가 없습니다',
     refresh: '새로고침',
     wipMessage: '작업 진행 중',
-    confirmDelete: '이 빌드를 삭제하시겠습니까?'
+    confirmDelete: '이 빌드를 삭제하시겠습니까?',
+    selectSubStats: 'Select Sub Stat',
+    back: 'Back'
   },
   de: {
     search: 'Suche',
@@ -83,7 +91,9 @@ export const uiTranslations: Record<string, UILabels> = {
     noBuilds: 'Keine Builds gefunden',
     refresh: 'Aktualisieren',
     wipMessage: 'In Arbeit',
-    confirmDelete: 'Möchten Sie diesen Build wirklich löschen?'
+    confirmDelete: 'Möchten Sie diesen Build wirklich löschen?',
+    selectSubStats: 'Select Sub Stat',
+    back: 'Back'
   },
   ja: {
     search: '検索',
@@ -100,7 +110,9 @@ export const uiTranslations: Record<string, UILabels> = {
     noBuilds: 'ビルドが見つかりません',
     refresh: '更新',
     wipMessage: '作業中',
-    confirmDelete: 'このビルドを削除してよろしいですか？'
+    confirmDelete: 'このビルドを削除してよろしいですか？',
+    selectSubStats: 'Select Sub Stat',
+    back: 'Back'
   },
   'zh-CN': {
     search: '搜索',
@@ -117,7 +129,9 @@ export const uiTranslations: Record<string, UILabels> = {
     noBuilds: '没有找到构建',
     refresh: '刷新',
     wipMessage: '开发中',
-    confirmDelete: '确定要删除此构建吗？'
+    confirmDelete: '确定要删除此构建吗？',
+    selectSubStats: 'Select Sub Stat',
+    back: 'Back'
   },
   'zh-TW': {
     search: '搜尋',
@@ -134,7 +148,9 @@ export const uiTranslations: Record<string, UILabels> = {
     noBuilds: '沒有找到構建',
     refresh: '重新整理',
     wipMessage: '開發中',
-    confirmDelete: '確定要刪除此構建嗎？'
+    confirmDelete: '確定要刪除此構建嗎？',
+    selectSubStats: 'Select Sub Stat',
+    back: 'Back'
   },
   it: {
     search: 'Cerca',
@@ -151,7 +167,9 @@ export const uiTranslations: Record<string, UILabels> = {
     noBuilds: 'Nessuna build trovata',
     refresh: 'Aggiorna',
     wipMessage: 'Lavori in corso',
-    confirmDelete: 'Sei sicuro di voler eliminare questa build?'
+    confirmDelete: 'Sei sicuro di voler eliminare questa build?',
+    selectSubStats: 'Select Sub Stat',
+    back: 'Back'
   },
   pl: {
     search: 'Szukaj',
@@ -168,7 +186,9 @@ export const uiTranslations: Record<string, UILabels> = {
     noBuilds: 'Brak zapisanych buildów',
     refresh: 'Odśwież',
     wipMessage: 'Prace w toku',
-    confirmDelete: 'Czy na pewno chcesz usunąć ten build?'
+    confirmDelete: 'Czy na pewno chcesz usunąć ten build?',
+    selectSubStats: 'Select Sub Stat',
+    back: 'Back'
   },
   pt: {
     search: 'Buscar',
@@ -185,7 +205,9 @@ export const uiTranslations: Record<string, UILabels> = {
     noBuilds: 'Nenhum build encontrado',
     refresh: 'Atualizar',
     wipMessage: 'Em desenvolvimento',
-    confirmDelete: 'Tem certeza de que deseja excluir este build?'
+    confirmDelete: 'Tem certeza de que deseja excluir este build?',
+    selectSubStats: 'Select Sub Stat',
+    back: 'Back'
   },
   ru: {
     search: 'Поиск',
@@ -202,7 +224,9 @@ export const uiTranslations: Record<string, UILabels> = {
     noBuilds: 'Билды не найдены',
     refresh: 'Обновить',
     wipMessage: 'В разработке',
-    confirmDelete: 'Вы уверены, что хотите удалить этот билд?'
+    confirmDelete: 'Вы уверены, что хотите удалить этот билд?',
+    selectSubStats: 'Select Sub Stat',
+    back: 'Back'
   },
   es: {
     search: 'Buscar',
@@ -219,7 +243,9 @@ export const uiTranslations: Record<string, UILabels> = {
     noBuilds: 'No se encontraron builds',
     refresh: 'Actualizar',
     wipMessage: 'Trabajo en progreso',
-    confirmDelete: '¿Estás seguro de que deseas eliminar esta build?'
+    confirmDelete: '¿Estás seguro de que deseas eliminar esta build?',
+    selectSubStats: 'Select Sub Stat',
+    back: 'Back'
   }
 };
 


### PR DESCRIPTION
## Summary
- show unique reactor images first and sub stats after selection
- keep search placeholder localized
- add translations for new labels

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_685948da29608320bf60ed5e22cd2deb