### PR TITLE
Add external type filtering

### DIFF
--- a/TFD-front/src/app/build/external/external.component.ts
+++ b/TFD-front/src/app/build/external/external.component.ts
@@ -26,12 +26,14 @@ export class ExternalBuildComponent {
   externalData: selectorData = {
     selectitems: 'externals',
     filterClass: 0,
-    descendant: undefined
+    descendant: undefined,
+    equipmentType: 0
   };
 
   constructor(private dialog: MatDialog) {}
 
   openDialog(): void {
+    this.externalData.equipmentType = this.index + 1;
     const dialogRef = this.dialog.open(selectorComponent, {
       autoFocus: true,
       data: this.externalData

--- a/TFD-front/src/app/build/selector/selector.component.ts
+++ b/TFD-front/src/app/build/selector/selector.component.ts
@@ -40,6 +40,7 @@ export class selectorComponent {
 
   filterClass: number;
   type: string = "";
+  equipmentType: number | undefined;
 
   searchText = '';
   requireDescendant = false;
@@ -119,6 +120,7 @@ export class selectorComponent {
 
   filteredExternals() {
     return this.data_store.externalResource.value()
+      ?.filter(ext => !this.equipmentType || ext.equipment_type_id === this.equipmentType)
   }
 
   get_translate(id: number): TranslationString {
@@ -134,6 +136,7 @@ export class selectorComponent {
     private dialogRef: MatDialogRef<selectorComponent>) {
     this.filterClass = data.filterClass ?? 0;
     this.type = data.selectitems;
+    this.equipmentType = data.equipmentType;
     // resources are preloaded in main component
   }
 

--- a/TFD-front/src/app/store/data.store.ts
+++ b/TFD-front/src/app/store/data.store.ts
@@ -265,5 +265,9 @@ export const dataStore = signalStore(
     refresh_externals: () => store.externalResource?.reload(),
     refresh_reactors: () => store.reactorResource?.reload(),
     refresh_boards: () => store.BoardResource?.reload(),
+    getExternalsByType: (type: number) => {
+      return store.externalResource.value()
+        ?.filter(ext => ext.equipment_type_id === type) ?? [];
+    },
   }))
 );

--- a/TFD-front/src/app/types/selector.types.ts
+++ b/TFD-front/src/app/types/selector.types.ts
@@ -2,4 +2,5 @@ export interface selectorData {
   selectitems: string;
   filterClass?: number;
   descendant?: number;
+  equipmentType?: number;
 }


### PR DESCRIPTION
## Summary
- support equipment type in selector data
- filter externals by equipment type in the selector component
- pass equipment type from external component when opening the dialog
- expose a helper in the data store to fetch externals by type

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_685dbf69fb008320b565373c8f29a2a7