### PR TITLE
Fix hold action context menu

### DIFF
--- a/TFD-front/src/app/directives/hold-action.directive.ts
+++ b/TFD-front/src/app/directives/hold-action.directive.ts
@@ -13,6 +13,11 @@ export class HoldActionDirective {
   private isHolding = false;
   private pointerDown = false;
 
+  @HostListener('contextmenu', ['$event'])
+  onContextMenu(event: Event): void {
+    event.preventDefault();
+  }
+
   @HostListener('pointerdown')
   onPointerDown(): void {
     this.isHolding = false;


### PR DESCRIPTION
## Summary
- prevent the default context menu when using `holdAction` directive

## Testing
- `npm test --silent` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6861cbe7b8b4832087befd064451ca72